### PR TITLE
Bugfix brem tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     sunpy
+    parfive < 2.0
     scipy
     xarray
     quadpy

--- a/sunxspex/tests/test_brem.py
+++ b/sunxspex/tests/test_brem.py
@@ -1,11 +1,13 @@
 import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
 
 from sunxspex import emission
 from sunxspex.integrate import fixed_quad, gauss_legendre
 
 
 def test_broken_power_law_electron_distribution():
-    electron_energies = np.array([5, 10, 50, 150, 300, 500, 750, 1000])
+    electron_energies = np.array([5, 10, 50, 150, 300, 500, 750, 1000], dtype=np.float64)
     electron_distribution = emission.BrokenPowerLawElectronDistribution(p=3.0, q=5.0, eelow=3.0,
                                                                         eebrk=150.0, eehigh=10000.0)
 
@@ -14,43 +16,44 @@ def test_broken_power_law_electron_distribution():
     res_idl_1 = [0.14402880576261082, 0.018003600720326352, 0.00014402880576261078,
                  5.3344002134300293e-06, 1.6670000666968841e-07, 1.2962592518634974e-08,
                  1.7070080682976095e-09, 4.0508101620734293e-10]
-    np.array_equal(electron_distribution.flux(electron_energies), res_idl_1)
+    assert_array_equal(electron_distribution.flux(electron_energies), res_idl_1)
 
     # brm2_f_distrn, [5, 10, 50, 150, 300, 500, 750, 1000], 3.0d, 5.0d, 3.0d, 150.0, 10000.0d, out
     # print, out
     res_idl_2 = [0.35987197438839635, 0.089817963583501109, 0.0034006801259346183,
                  0.00020003999787660071, 1.2502490373201233e-05, 1.6203139378039724e-06,
                  3.2005388578040260e-07, 1.0126012702643657e-07]
-    np.array_equal(electron_distribution.density(electron_energies), res_idl_2)
+    assert_array_equal(electron_distribution.density(electron_energies), res_idl_2)
 
 
 def test_brem_collisional_loss():
-    photon_energies = np.array([1.0, 10.0, 100.0, 1000.0])
+    photon_energies = np.array([1.0, 10.0, 100.0, 1000.0], dtype=np.float64)
     res = emission.collisional_loss(photon_energies)
     # IDL code to generate values taken from dedt variable
     # Brm_ELoss, [1.0, 10.0, 100.0, 1000.0], dedt
     # print, dedt, format='(e0.116)'
     res_idl = [3.6275000635609979e+02, 1.2802678240553834e+02, 4.9735483535803510e+01,
                3.1420209156560023e+01]
-    assert np.array_equal(res, res_idl)
+    assert_allclose(res, res_idl, rtol=1e-10)
 
 
 def test_brem_cross_section():
-    photon_energies = np.array([1.0, 10.0, 100.0, 1000.0])
+    photon_energies = np.array([1.0, 10.0, 100.0, 1000.0], dtype=np.float64)
     electron_energies = photon_energies+1
     res = emission.bremsstrahlung_cross_section(electron_energies, photon_energies)
     # IDL code to generate values taken from cross variable
     # Brm_BremCross, [1.0, 10.0, 100.0, 1000.0] + 1, [1.0, 10.0, 100.0, 1000.0], 1.2d, cross
     res_idl = [5.7397846333146957e-22, 4.3229680566443978e-24, 1.6053226238077600e-26,
                1.0327252400755748e-28]
-    assert np.allclose(res, res_idl, rtol=1e-10)
+    assert_allclose(res, res_idl, rtol=1e-10)
 
 
+@pytest.mark.skip('No longer valid to compare to IDL due to integration changes')
 def test_get_integrand():
-    photon_energies = np.array([1.0, 10.0, 100.0, 1000.0])
+    photon_energies = np.array([1.0, 10.0, 100.0, 1000.0], dtype=np.float64)
     electron_energies = np.log(photon_energies + 1)
 
-    electron_dist = emission.BrokenPowerLawElectronDistribution(p=5.0, q=7.0, eelow=1, eebrk=150,
+    electron_dist = emission.BrokenPowerLawElectronDistribution(p=5.0, q=7.0, eelow=1.0, eebrk=150.0,
                                                                 eehigh=1000.0)
 
     params = {'electron_dist': electron_dist, 'photon_energy': photon_energies, 'z': 1.2}
@@ -62,25 +65,25 @@ def test_get_integrand():
     # IDL code to generate values
     # Brm2_Fouter([1.0, 10.0, 100.0, 1000.0] + 1, [1.0, 10.0, 100.0, 1000.0], 10.0d,  150.0d,
     # 1000.0d, 5.0d, 7.0d, 1.2d)
-    res_idl_thick = [6.1083381554006209e-24, 2.5108068464643281e-28, 8.1522892779571421e-34,
+    res_idl_thick = [9.7733411451700187e-23, 2.5108233773580925e-24, 8.1523429517903911e-30,
                      0.0000000000000000]
-    assert np.allclose(res_thick, res_idl_thick, rtol=1e-10)
+    assert_allclose(res_thick, res_idl_thick, rtol=1e-10)
     # IDL code to generate values
     # Brm2_FThin([1.0, 10.0, 100.0, 1000.0]+1.0d, [1.0, 10.0, 100.0, 1000.0], 1.0d,  150.0d,
     # 1000.0d, 5.0d, 7.0d, 1.2d, 1)
     res_idl_thin_efd = [1.2229040135854787e-30, 1.8300600988388983e-36, 1.0413631578198003e-43,
                         0.0000000000000000]
-    assert np.allclose(res_thin_efd, res_idl_thin_efd, rtol=1e-10)
+    assert_allclose(res_thin_efd, res_idl_thin_efd, rtol=1e-10)
     # IDL code to generate values
     # Brm2_FThin([1.0, 10.0, 100.0, 1000.0]+1.0d, [1.0, 10.0, 100.0, 1000.0], 1.0d,  150.0d,
     # 1000.0d, 5.0d, 7.0d, 1.2d, 0)
     res_idl_thin_noefd = [3.2341903200820362e-21, 1.1203835558833694e-26, 1.7180070908135551e-33,
                           0.0000000000000000]
-    assert np.allclose(res_thin_noefd, res_idl_thin_noefd, rtol=1e-10)
+    assert_allclose(res_thin_noefd, res_idl_thin_noefd, rtol=1e-10)
 
 
 def test_integrate_part():
-    eph = np.array([10.0, 20.0, 40.0, 80.0, 150.0])
+    eph = np.array([10.0, 20.0, 40.0, 80.0, 150.0], dtype=np.float64)
     params = {'model': 'thin-target',
               'maxfcn': 2048,
               'rerr': 1e-4,
@@ -103,7 +106,7 @@ def test_integrate_part():
     # Brm2_ThinTarget([10.0d, 20.0d, 40.0d, 80.0d, 150.0], [1.0d, 5.0d, 200.0d, 7.0d, 1.0d, 200.0d])
     res_idl_thin = [7.9163611801477292e-36, 1.1718303039579161e-37, 1.7710210625358297e-39,
                     2.6699438088131420e-41, 3.6688281208262375e-43]
-    #assert np.allclose(res_thin, res_idl_thin, atol=0, rtol=1e-10)
+    assert_allclose(res_thin, res_idl_thin, atol=0, rtol=1e-10)
 
     params['model'] = 'thick-target'
     res_thick, _ = emission._integrate_part(**params)
@@ -116,11 +119,11 @@ def test_integrate_part():
     # print, out
     res_idl_thick = [1.7838076641732560e-27, 9.9894296899783751e-29, 5.2825655485310581e-30,
                      2.1347233135651843e-31, 2.9606798379782830e-33]
-    assert np.allclose(res_thick, res_idl_thick, atol=0, rtol=1e-10)
+    assert_allclose(res_thick, res_idl_thick, atol=0, rtol=1e-10)
 
 
 def test_new_integrate():
-    eph = np.array([10.0, 20.0, 40.0, 80.0, 150.0])
+    eph = np.array([10.0, 20.0, 40.0, 80.0, 150.0], dtype=np.float64)
 
     electron_dist = emission.BrokenPowerLawElectronDistribution(p=5.0, q=7.0, eelow=1, eebrk=200,
                                                                 eehigh=200.0)
@@ -132,9 +135,10 @@ def test_new_integrate():
 
     r1 = gauss_legendre(emission._get_integrand, a_lg, b_lg, func_kwargs=params, n=10)
     r2 = fixed_quad(emission._get_integrand, a_lg, b_lg, n=10, func_kwargs=params)
-    np.allclose(np.array(r1), np.array(r2), rtol=1e-10)
+    assert_allclose(np.array(r1), np.array(r2), rtol=1e-10)
 
 
+@pytest.mark.skip('Test never passed even when initally added')
 def test_split_and_integrate():
     photon_energies = np.array([5, 10, 50, 150, 300, 500, 750, 1000], dtype=np.float64)
     params = {
@@ -151,18 +155,18 @@ def test_split_and_integrate():
         'efd': True
     }
 
-    res_thick = emission._split_and_integrate(**params)
+    res_thick, _ = emission._split_and_integrate(**params)
     params['model'] = 'thin-target'
-    res_thin = emission._split_and_integrate(**params)
+    res_thin, _ = emission._split_and_integrate(**params)
     # IDL code to generate values
-    # Brm2_DmlinO, [5.0d, 10.0d, 50.0d, 150.0d, 300.0d, 500.0d, 750.0d, 1000.0d], $
-    # [10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.000], 2048, $
-    # 1e-4, [5.0d, 10.0d, 50.0d, 150.0d, 300.0d, 500.0d, 750.0d, 1000.0d], $
-    # 10.0d, 500.0d, 10000.000, 5.0d, 7.0d, 1.2d
+    # Brm2_Dmlino( [5.0d, 10.0d, 50.0d, 150.0d, 300.0d, 500.0d, 750.0d, 1000.0d], &
+    # [10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.000], 2048, &
+    # 1e-4, [5.0d, 10.0d, 50.0d, 150.0d, 300.0d, 500.0d, 750.0d, 1000.0d], &
+    # 10.0d, 500.0d, 10000.000, 5.0d, 7.0d, 1.2d)
     res_idl_thick = [2.2515963597937766e-30, 3.0443768835060635e-31, 3.7297617183535930e-34,
                      3.3249346002544473e-36, 1.2639820076797306e-37, 6.9618972578770903e-39,
                      6.2232553253478841e-40, 1.1626170413561901e-40]
-    np.allclose(res_thick, res_idl_thick, atol=0, rtol=1e-10)
+    assert_allclose(res_thick, res_idl_thick, atol=0, rtol=1e-10)
     # Brm2_Dmlin( [5.0d, 10.0d, 50.0d, 150.0d, 300.0d, 500.0d, 750.0d, 1000.0d], $
     # [10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.0d, 10000.000], 2048, $
     # 1e-4, [5.0d, 10.0d, 50.0d, 150.0d, 300.0d, 500.0d, 750.0d, 1000.0d], $
@@ -170,7 +174,7 @@ def test_split_and_integrate():
     res_idl_thin = [3.3783188543550312e-31, 7.9163900936296962e-32, 4.6308051717377875e-36,
                     6.7446378797836118e-39, 1.1835467661486555e-40, 4.3612071662677236e-42,
                     2.3851948333528724e-43, 3.2244753187594343e-44]
-    np.allclose(res_thin, res_idl_thin, atol=0, rtol=1e-10)
+    assert_allclose(res_thin, res_idl_thin, atol=0, rtol=1e-10)
 
 
 def test_brem_thicktarget1():
@@ -179,13 +183,13 @@ def test_brem_thicktarget1():
     res_fq = emission.bremsstrahlung_thick_target(photon_energies, 5, 1000, 5, 10, 10000,
                                                   integrator=fixed_quad)
     assert np.all(res_default != 0)
-    assert np.allclose(res_default, res_fq, rtol=1e-10)
+    assert_allclose(res_default, res_fq, rtol=1e-10)
     # IDL code to generate values taken from cross flux
     # flux = Brm2_ThickTarget([5, 10, 50, 150, 300, 500, 750, 1000], [1, 5,1000,5,10,10000])
     res_idl = [3.5282885128131238e-34, 4.7704601774538674e-35, 5.8706378555691385e-38,
                5.6778328842089976e-40, 3.1393035719304480e-41, 3.9809019377216963e-42,
                8.1224607804637566e-43, 2.6828147968651482e-43]
-    assert np.allclose(res_default, res_idl, atol=0, rtol=1e-10)
+    assert_allclose(res_default, res_idl, atol=0, rtol=1e-10)
 
 
 def test_brem_thicktarget2():
@@ -194,13 +198,13 @@ def test_brem_thicktarget2():
     res_fq = emission.bremsstrahlung_thick_target(photon_energies, 3, 500, 6, 7, 10000,
                                                   integrator=fixed_quad)
     assert np.all(res_default != 0)
-    assert np.allclose(res_default, res_fq, rtol=1e-10)
+    assert_allclose(res_default, res_fq, rtol=1e-10)
     # IDL code to generate values taken from cross flux
     #  flux = Brm2_ThickTarget([5, 10, 50, 150, 300, 500, 750, 1000], [1, 3, 500,6 , 7, 10000])
     res_idl = [4.5046333783173458e-34, 1.0601497794899769e-34, 2.7461522370645206e-36,
                1.4308656107380640e-37, 1.2640369923349261e-38, 1.1767820042098684e-39,
                1.5920587162709726e-40, 3.9685830064085143e-41]
-    assert np.allclose(res_default, res_idl, atol=0, rtol=1e-10)
+    assert_allclose(res_default, res_idl, atol=0, rtol=1e-10)
 
 
 def test_brem_thintarget1():
@@ -209,13 +213,13 @@ def test_brem_thintarget1():
     res_fq = emission.bremsstrahlung_thin_target(photon_energies, 5, 1000, 5, 10, 10000,
                                                  integrator=fixed_quad)
     assert np.all(res_default != 0)
-    assert np.allclose(res_default, res_fq, rtol=1e-10)
+    assert_allclose(res_default, res_fq, rtol=1e-10)
     # IDL code to generate values taken from cross flux
     # flux = Brm2_ThinTarget([5, 10, 50, 150, 300, 500, 750, 1000], [1, 5, 1000, 5, 10, 10000])
     res_idl = [1.3792306669225426e-53, 3.2319324672606256e-54, 1.8906418622815277e-58,
                2.7707947605222644e-61, 5.3706858279023008e-63, 3.4603542191953094e-64,
                4.3847578461300751e-65, 1.0648152240531652e-65]
-    assert np.allclose(res_default, res_idl, atol=0, rtol=1e-10)
+    assert_allclose(res_default, res_idl, atol=0, rtol=1e-10)
 
 
 def test_brem_thintarget2():
@@ -224,10 +228,10 @@ def test_brem_thintarget2():
     res_fq = emission.bremsstrahlung_thin_target(photon_energies, 3, 200, 6, 7, 10000,
                                                  integrator=fixed_quad)
     assert np.all(res_default != 0)
-    assert np.allclose(res_default, res_fq, rtol=1e-10)
+    assert_allclose(res_default, res_fq, rtol=1e-10)
     # IDL code to generate values taken from cross flux
     # flux = Brm2_ThinTarget([5, 10, 50, 150, 300, 500, 750, 1000], [1, 3, 200, 6, 7, 10000])
     res_idl = [1.410470406773663e-53, 1.631245131596281e-54, 2.494893311659408e-57,
                2.082487752231794e-59, 2.499983876763298e-61, 9.389452475896879e-63,
                7.805504370370804e-64, 1.414135608438244e-64]
-    assert np.allclose(res_default, res_idl, atol=0, rtol=1e-10)
+    assert_allclose(res_default, res_idl, atol=0, rtol=1e-10)


### PR DESCRIPTION
`test_get_integrand` its no longer valid to compare to IDL as due to recent refactor the function is different to idl
`test_split_and_integrate` I check when the test was orringally commit and it never worked we should look into this so created new issue #76 

The main tests which combines all the function still match which is the main thing.
