### PR TITLE
Cstat fix

### DIFF
--- a/changelog/85.bugfix.rst
+++ b/changelog/85.bugfix.rst
@@ -1,1 +1,1 @@
-Added in special case when a data bin has zero counts in it for the C-stat likelihood, it defaults to the Poisson likelihood now when data is zero.
+Added special case in C-stat likelihood function :func:`sunxspex/sunxspex_fitting/likelihoods.LogLikelihoods.cstat_loglikelihood` it defaults to the Poisson likelihood now when data is zero.

--- a/changelog/85.bugfix.rst
+++ b/changelog/85.bugfix.rst
@@ -1,0 +1,1 @@
+Added in special case when a data bin has zero counts in it for the C-stat likelihood, it defaults to the Poisson likelihood now when data is zero.

--- a/sunxspex/conftest.py
+++ b/sunxspex/conftest.py
@@ -8,10 +8,10 @@
 # To ignore some packages that produce deprecation warnings on import
 # (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
 # 'setuptools'), add:
-##     modules_to_ignore_on_import=['module_1', 'module_2']
+# modules_to_ignore_on_import=['module_1', 'module_2']
 # To ignore some specific deprecation warning messages for Python version
 # MAJOR.MINOR or later, add:
-##     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
+# warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
 # enable_deprecations_as_exceptions()
 
 # Uncomment and customize the following lines to add/remove entries from

--- a/sunxspex/sunxspex_fitting/likelihoods.py
+++ b/sunxspex/sunxspex_fitting/likelihoods.py
@@ -254,7 +254,7 @@ class LogLikelihoods:
         A float, the c-stat log-likelihood (to be maximised).
         """
 
-        model_counts, observed_counts, observed_count_errors = np.array(model_counts).squeeze(), np.array(observed_counts), np.array(observed_count_errors)
+        model_counts, observed_counts, observed_count_errors = np.array(model_counts).ravel(), np.array(observed_counts), np.array(observed_count_errors)
 
         # C-stat (XSPEC) - has data term in it so the lower the -2*ln(L) number the better the fit, this is the ln(L) though
         # Best value is 0, if obs_counts>mod_counts or obs_counts<mod_counts then likelihoods<0

--- a/sunxspex/sunxspex_fitting/likelihoods.py
+++ b/sunxspex/sunxspex_fitting/likelihoods.py
@@ -254,7 +254,7 @@ class LogLikelihoods:
         A float, the c-stat log-likelihood (to be maximised).
         """
 
-        model_counts, observed_counts, observed_count_errors = np.array(model_counts), np.array(observed_counts), np.array(observed_count_errors)
+        model_counts, observed_counts, observed_count_errors = np.array(model_counts).squeeze(), np.array(observed_counts), np.array(observed_count_errors)
 
         # C-stat (XSPEC) - has data term in it so the lower the -2*ln(L) number the better the fit, this is the ln(L) though
         # Best value is 0, if obs_counts>mod_counts or obs_counts<mod_counts then likelihoods<0

--- a/sunxspex/sunxspex_fitting/likelihoods.py
+++ b/sunxspex/sunxspex_fitting/likelihoods.py
@@ -254,15 +254,18 @@ class LogLikelihoods:
         A float, the c-stat log-likelihood (to be maximised).
         """
 
+        model_counts, observed_counts, observed_count_errors = np.array(model_counts), np.array(observed_counts), np.array(observed_count_errors)
+
         # C-stat (XSPEC) - has data term in it so the lower the -2*ln(L) number the better the fit, this is the ln(L) though
         # Best value is 0, if obs_counts>mod_counts or obs_counts<mod_counts then likelihoods<0
         # Obvious since e^0=1
-        likelihoods = np.array(observed_counts) * (np.log(np.array(model_counts)/np.array(observed_counts)) + 1) - np.array(model_counts)
+        likelihoods = observed_counts * (np.log(model_counts/observed_counts) + 1) - model_counts
 
         # if zero observed counts in a bin, then Stirling Approx. not good (only good for obs_counts>=1, if =0 then ->-inf, but Poisson->-mod_counts)
         # defer to Poisson for the nans in this case
-        if len(likelihoods[~np.isfinite(likelihoods)]) > 0:
-            likelihoods[~np.isfinite(likelihoods)] = -model_counts[~np.isfinite(likelihoods)]
+        _zero_data = (observed_counts == 0) & (model_counts > 0)
+        if len(observed_counts[_zero_data]) > 0:
+            likelihoods[_zero_data] = -model_counts[_zero_data]
 
         return self._check_numbers_left(self.remove_non_numbers(likelihoods))
 

--- a/sunxspex/sunxspex_fitting/tests/test_likelihoods.py
+++ b/sunxspex/sunxspex_fitting/tests/test_likelihoods.py
@@ -1,0 +1,57 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from sunxspex.sunxspex_fitting.likelihoods import LogLikelihoods
+
+
+def test_cstat():
+
+    # c-stat shouldn't depend on errors, assumes poissonian
+    observed_count_errors = 0
+
+    # fake counts, fake model, and their expected cstat log-likelihood output
+    # these should default to Poisson log-likelihood as well
+    fake_model1p, fake_counts1p, cstat1p = [0], [0], -np.inf
+    fake_model2p, fake_counts2p, cstat2p = [0], [1], -np.inf
+    fake_model3p, fake_counts3p, cstat3p = [1], [0], -1
+
+    # calculate c-stat
+    cstat1p_result = LogLikelihoods().cstat_loglikelihood(model_counts=fake_model1p, observed_counts=fake_counts1p, observed_count_errors=observed_count_errors)
+    cstat2p_result = LogLikelihoods().cstat_loglikelihood(model_counts=fake_model2p, observed_counts=fake_counts2p, observed_count_errors=observed_count_errors)
+    cstat3p_result = LogLikelihoods().cstat_loglikelihood(model_counts=fake_model3p, observed_counts=fake_counts3p, observed_count_errors=observed_count_errors)
+
+    # check agreement
+    assert_allclose(cstat1p_result, cstat1p, rtol=1e-3)
+    assert_allclose(cstat2p_result, cstat2p, rtol=1e-3)
+    assert_allclose(cstat3p_result, cstat3p, rtol=1e-3)
+
+    # calculate the Poissonian values
+    poisson1p_result = LogLikelihoods().poisson_loglikelihood(model_counts=fake_model1p, observed_counts=fake_counts1p, observed_count_errors=observed_count_errors)
+    poisson2p_result = LogLikelihoods().poisson_loglikelihood(model_counts=fake_model2p, observed_counts=fake_counts2p, observed_count_errors=observed_count_errors)
+    poisson3p_result = LogLikelihoods().poisson_loglikelihood(model_counts=fake_model3p, observed_counts=fake_counts3p, observed_count_errors=observed_count_errors)
+
+    # compare where C-stat should produce same as Poissonian
+    assert_allclose(cstat1p_result, poisson1p_result, rtol=1e-3)
+    assert_allclose(cstat2p_result, poisson2p_result, rtol=1e-3)
+    assert_allclose(cstat3p_result, poisson3p_result, rtol=1e-3)
+
+    # other test cases
+    fake_model1, fake_counts1, cstat1 = [10], [10], 0
+    fake_model2, fake_counts2, cstat2 = [10], [50], -40.472
+    fake_model3, fake_counts3, cstat3 = [10, 10], [10, 50], cstat1+cstat2
+    fake_model4, fake_counts4, cstat4 = [10, 50], [10, 0], -50
+    fake_model5, fake_counts5, cstat5 = [10, 10, 10, 50], [10, 50, 10, 0], cstat3+cstat4
+
+    # calculate c-stat
+    cstat1_result = LogLikelihoods().cstat_loglikelihood(model_counts=fake_model1, observed_counts=fake_counts1, observed_count_errors=observed_count_errors)
+    cstat2_result = LogLikelihoods().cstat_loglikelihood(model_counts=fake_model2, observed_counts=fake_counts2, observed_count_errors=observed_count_errors)
+    cstat3_result = LogLikelihoods().cstat_loglikelihood(model_counts=fake_model3, observed_counts=fake_counts3, observed_count_errors=observed_count_errors)
+    cstat4_result = LogLikelihoods().cstat_loglikelihood(model_counts=fake_model4, observed_counts=fake_counts4, observed_count_errors=observed_count_errors)
+    cstat5_result = LogLikelihoods().cstat_loglikelihood(model_counts=fake_model5, observed_counts=fake_counts5, observed_count_errors=observed_count_errors)
+
+    # check agreement
+    assert_allclose(cstat1_result, cstat1, rtol=1e-3)
+    assert_allclose(cstat2_result, cstat2, rtol=1e-3)
+    assert_allclose(cstat3_result, cstat3, rtol=1e-3)
+    assert_allclose(cstat4_result, cstat4, rtol=1e-3)
+    assert_allclose(cstat5_result, cstat5, rtol=1e-3)


### PR DESCRIPTION
The C-stat likelihood doesn't handle bins of 0 observed counts correctly. In this case, revert to the Poissonian log-likelihood. This means at Data=0, ln(likelihood)=-model.
