### PR TITLE
count_rate2counts should be dealing with the average, so no need for integers

### DIFF
--- a/changelog/87.bugfix.rst
+++ b/changelog/87.bugfix.rst
@@ -1,0 +1,1 @@
+Values are now left as floats when converting the model count rates (counts/second) to just counts since the model represents the average number of counts; therefore, there is not need for these to be integers.

--- a/changelog/87.bugfix.rst
+++ b/changelog/87.bugfix.rst
@@ -1,1 +1,1 @@
-Values are now left as floats when converting the model count rates (counts/second) to just counts since the model represents the average number of counts; therefore, there is not need for these to be integers.
+Removed cast to `int` when converting the model count rates (counts/second) to just counts since the model represents the average number of counts, there is not need for these to be integers.

--- a/sunxspex/conftest.py
+++ b/sunxspex/conftest.py
@@ -8,10 +8,10 @@
 # To ignore some packages that produce deprecation warnings on import
 # (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
 # 'setuptools'), add:
-##     modules_to_ignore_on_import=['module_1', 'module_2']
+# modules_to_ignore_on_import=['module_1', 'module_2']
 # To ignore some specific deprecation warning messages for Python version
 # MAJOR.MINOR or later, add:
-##     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
+# warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
 # enable_deprecations_as_exceptions()
 
 # Uncomment and customize the following lines to add/remove entries from

--- a/sunxspex/sunxspex_fitting/fitter.py
+++ b/sunxspex/sunxspex_fitting/fitter.py
@@ -1498,7 +1498,7 @@ class SunXspex:
             return allowed
 
     def _count_rate2count(self, counts_model, livetime):
-        """ Convert a count rate [counts s^-1] to just counts.
+        """ Convert an average count rate [counts s^-1] to just counts.
 
         Parameters
         ----------
@@ -1512,7 +1512,7 @@ class SunXspex:
         -------
         Array or lists of count spectra.
         """
-        return (counts_model * livetime).astype(int)
+        return counts_model * livetime
 
     def _choose_loglikelihood(self):
         """ Access the log_likelihoods attribute.


### PR DESCRIPTION
Not right to cast model counts to integers since this is supposed to be the model average in the time range being looked at and so it can be a float, it is the count data that must be integers. Casting to integers the way I did can also cause weird value overflows.