### PR TITLE
Fixed the way random walker starts are picked over a boundary 

### DIFF
--- a/changelog/89.bugfix.rst
+++ b/changelog/89.bugfix.rst
@@ -1,1 +1,1 @@
-Starting random walker positions over the parameter space for MCMC analysis are now obtained correctly and does not rely on all upper parameter bounds being >0.01.
+Fix bug where MCMC random walker starter positions were not correctly calculated.

--- a/changelog/89.bugfix.rst
+++ b/changelog/89.bugfix.rst
@@ -1,0 +1,1 @@
+Starting random walker positions over the parameter space for MCMC analysis are now obtained correctly and does not rely on all upper parameter bounds being >0.01.

--- a/sunxspex/conftest.py
+++ b/sunxspex/conftest.py
@@ -8,10 +8,10 @@
 # To ignore some packages that produce deprecation warnings on import
 # (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
 # 'setuptools'), add:
-##     modules_to_ignore_on_import=['module_1', 'module_2']
+# modules_to_ignore_on_import=['module_1', 'module_2']
 # To ignore some specific deprecation warning messages for Python version
 # MAJOR.MINOR or later, add:
-##     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
+# warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
 # enable_deprecations_as_exceptions()
 
 # Uncomment and customize the following lines to add/remove entries from

--- a/sunxspex/sunxspex_fitting/fitter.py
+++ b/sunxspex/sunxspex_fitting/fitter.py
@@ -3896,9 +3896,9 @@ class SunXspex:
         lowers[lowers == None] = -2**32  # -np.inf # for the random int generatation, these have to be numbers. Make it largest 32-bit number
         uppers = value_bounds[:, 1][:, None]  # = []
         uppers[uppers == None] = 2**32  # np.inf
-        vbounds = np.concatenate((lowers, uppers), axis=1)*100
+        vbounds = np.concatenate((lowers, uppers), axis=1)
 
-        return np.array([list(np.random.randint(*vb, number)/100) for vb in vbounds]).T
+        return np.array([list(vb[0]+(vb[1]-vb[0])*np.random.rand(number)) for vb in vbounds]).T
 
     def _walker_spread(self, value, value_bounds, number, spread_type="mixed"):
         """ Calculate a spread of walker starting positions.

--- a/sunxspex/sunxspex_fitting/fitter.py
+++ b/sunxspex/sunxspex_fitting/fitter.py
@@ -3893,9 +3893,9 @@ class SunXspex:
         # sort boundaries into numbers first if there are Nones
         value_bounds = np.array(value_bounds)
         lowers = value_bounds[:, 0][:, None]  # = []
-        lowers[lowers == None] = -2**32  # -np.inf # for the random int generatation, these have to be numbers. Make it largest 32-bit number
+        lowers[lowers == None] = -np.iinfo(np.int32).max  # -np.inf # for the random int generatation, these have to be numbers. Make it largest 32-bit number
         uppers = value_bounds[:, 1][:, None]  # = []
-        uppers[uppers == None] = 2**32  # np.inf
+        uppers[uppers == None] = np.iinfo(np.int32).max  # np.inf
         vbounds = np.concatenate((lowers, uppers), axis=1)
 
         return np.array([list(vb[0]+(vb[1]-vb[0])*np.random.rand(number)) for vb in vbounds]).T

--- a/sunxspex/sunxspex_fitting/tests/test_fitter.py
+++ b/sunxspex/sunxspex_fitting/tests/test_fitter.py
@@ -135,3 +135,29 @@ def test_fitter_load(custom_spec, tmp_path):
     assert_allclose(minimiser_results[3], b[0], rtol=1e-3)
     assert_allclose(minimiser_results[4], b[1], rtol=1e-3)
     assert_allclose(minimiser_results[5], b[2], rtol=1e-2)
+
+
+def _assert_in_range(bounds, values):
+    """Raise assertion if the values given are within certain bounds.
+
+    I.e., lower_bound <= values <= upper_bound
+    """
+    assert np.all((bounds[0] <= values) & (values <= bounds[1])), "Value(s) not within bounds given."
+
+
+def test_mcmc_walker_boundary_spread():
+    # test lower and upper boundaries, [(lower,upper),(lower,upper),...]
+    list_of_tuple_bounds1, number_of_values1 = [(1, 10)], 1
+    list_of_tuple_bounds2, number_of_values2 = [(0.005, 0.3)], 5
+    list_of_tuple_bounds3, number_of_values3 = [(1, 10), (0.005, 0.3)], 10
+
+    # get `number` entries between all bounds in `value_bounds`
+    spread1 = SunXspex()._boundary_spread(value_bounds=list_of_tuple_bounds1, number=number_of_values1)
+    spread2 = SunXspex()._boundary_spread(value_bounds=list_of_tuple_bounds2, number=number_of_values2)
+    spread3 = SunXspex()._boundary_spread(value_bounds=list_of_tuple_bounds3, number=number_of_values3)
+
+    # check values produced are within the bounds
+    _assert_in_range(list_of_tuple_bounds1[0], spread1[:, 0])
+    _assert_in_range(list_of_tuple_bounds2[0], spread2[:, 0])
+    _assert_in_range(list_of_tuple_bounds3[0], spread3[:, 0])
+    _assert_in_range(list_of_tuple_bounds3[1], spread3[:, 1])


### PR DESCRIPTION
The way I did this in the first place was stupid. Originally the parameter space bounds were multiplied by 100 and then I choose random integer values (why do I want to make everything an integer!?) within the new scaled bounds. This is obviously not right.

The new way is done as L+(U-L)*R, where L and R are the lower and upper bounds for the parameter space and R is a random value between 0 and 1. This should now give values that make sense no matter the bounds.
