### PR TITLE
Fixes STIX file loading and lightcurve/spectrogram plotting

### DIFF
--- a/changelog/98.breaking.rst
+++ b/changelog/98.breaking.rst
@@ -1,0 +1,1 @@
+Update STIX spectrogram and srm loading and plotting functions for the new STIX file format.

--- a/sunxspex/sunxspex_fitting/instruments.py
+++ b/sunxspex/sunxspex_fitting/instruments.py
@@ -1110,7 +1110,7 @@ class RhessiLoader(InstrumentBlueprint):
         List of matplotlib dates.
         """
         # convert astro time to datetime then use list comprehension to convert to matplotlib dates
-        return [mdates.date2num(dt.tt.datetime) for dt in astrotimes]
+        return [mdates.date2num(dt.utc.datetime) for dt in astrotimes]
 
     def _mdates_minute_locator(self, _obs_dt=None):
         """ Try to determine a nice tick separation for time axis on the lightcurve.
@@ -1290,12 +1290,12 @@ class RhessiLoader(InstrumentBlueprint):
         _y_pos = ax.get_ylim()[0] + (ax.get_ylim()[1]-ax.get_ylim()[0])*0.95  # stop region label overlapping axis spine
         if hasattr(self, "_start_background_time") and (type(self._start_background_time) != type(None)) and hasattr(self, "_end_background_time") and (type(self._end_background_time) != type(None)):
             ax.axvspan(*self._atimes2mdates([self._start_background_time, self._end_background_time]), alpha=0.1, color='orange')
-            ax.annotate("BG", (self._atimes2mdates([self._start_background_time])[0], _y_pos), color='orange', va="top", size=_def_fs-8)
+            ax.annotate("BG", (self._atimes2mdates([self._start_background_time])[0], _y_pos), color='orange', va="top", size=_def_fs-2)
 
         # plot event time range
         if hasattr(self, "_start_event_time") and hasattr(self, "_end_event_time"):
             ax.axvspan(*self._atimes2mdates([self._start_event_time, self._end_event_time]), alpha=0.1, color='purple')
-            ax.annotate("Evt", (self._atimes2mdates([self._start_event_time])[0], _y_pos), color='purple', va="top", size=_def_fs-8)
+            ax.annotate("Evt", (self._atimes2mdates([self._start_event_time])[0], _y_pos), color='purple', va="top", size=_def_fs-2)
 
         self._lightcurve_data = {"mdtimes": _ts, "lightcurves": _lcs, "lightcurve_error": _lcs_err, "energy_ranges": energy_ranges}
 
@@ -1395,16 +1395,19 @@ class RhessiLoader(InstrumentBlueprint):
 
         ax.set_title(self._instrument()+"Spectrogram [Counts s$^{-1}$]")
 
+        # change event and background start and end times from astropy dates to matplotlib dates
+        start_evt_time, end_evt_time, start_bg_time, end_bg_time = self._atimes2mdates([self._start_event_time, self._end_event_time, self._start_background_time, self._end_background_time])
+
         # plot background time range if there is one
         _y_pos = ax.get_ylim()[0] + (ax.get_ylim()[1]-ax.get_ylim()[0])*0.95  # stop region label overlapping axis spine
         if hasattr(self, "_start_background_time") and (type(self._start_background_time) != type(None)) and hasattr(self, "_end_background_time") and (type(self._end_background_time) != type(None)):
-            ax.plot(self._atimes2mdates([self._start_background_time, self._end_background_time]), [etop, etop], alpha=0.9, color='orange', lw=10)
-            ax.annotate("BG", (self._atimes2mdates([self._start_background_time])[0], _y_pos), color='orange', va="top", size=_def_fs-8)
+            ax.hlines(y=etop, xmin=start_bg_time, xmax=end_bg_time ,alpha=0.9, color='orange',capstyle='butt', lw=10)
+            ax.annotate("BG", (start_bg_time, _y_pos), color='orange', va="top", size=_def_fs-2)
 
         # plot event time range
         if hasattr(self, "_start_event_time") and hasattr(self, "_end_event_time"):
-            ax.plot(self._atimes2mdates([self._start_event_time, self._end_event_time]), [etop, etop], alpha=0.9, color='#F37AFF', lw=10)
-            ax.annotate("Evt", (self._atimes2mdates([self._start_event_time])[0], _y_pos), color='#F37AFF', va="top", size=_def_fs-8)
+            ax.hlines(y=etop, xmin=start_evt_time, xmax=end_evt_time ,alpha=0.9, color='#F37AFF',capstyle = 'butt', lw=10)
+            ax.annotate("Evt", (start_evt_time, _y_pos), color='#F37AFF', va="top", size=_def_fs-2)
 
         self._spectrogram_data = {"spectrogram": _spect, "extent": _ext}
 

--- a/sunxspex/sunxspex_fitting/instruments.py
+++ b/sunxspex/sunxspex_fitting/instruments.py
@@ -1401,12 +1401,12 @@ class RhessiLoader(InstrumentBlueprint):
         # plot background time range if there is one
         _y_pos = ax.get_ylim()[0] + (ax.get_ylim()[1]-ax.get_ylim()[0])*0.95  # stop region label overlapping axis spine
         if hasattr(self, "_start_background_time") and (type(self._start_background_time) != type(None)) and hasattr(self, "_end_background_time") and (type(self._end_background_time) != type(None)):
-            ax.hlines(y=etop, xmin=start_bg_time, xmax=end_bg_time ,alpha=0.9, color='orange',capstyle='butt', lw=10)
+            ax.hlines(y=etop, xmin=start_bg_time, xmax=end_bg_time, alpha=0.9, color='orange', capstyle='butt', lw=10)
             ax.annotate("BG", (start_bg_time, _y_pos), color='orange', va="top", size=_def_fs-2)
 
         # plot event time range
         if hasattr(self, "_start_event_time") and hasattr(self, "_end_event_time"):
-            ax.hlines(y=etop, xmin=start_evt_time, xmax=end_evt_time ,alpha=0.9, color='#F37AFF',capstyle = 'butt', lw=10)
+            ax.hlines(y=etop, xmin=start_evt_time, xmax=end_evt_time, alpha=0.9, color='#F37AFF', capstyle='butt', lw=10)
             ax.annotate("Evt", (start_evt_time, _y_pos), color='#F37AFF', va="top", size=_def_fs-2)
 
         self._spectrogram_data = {"spectrogram": _spect, "extent": _ext}

--- a/sunxspex/sunxspex_fitting/io.py
+++ b/sunxspex/sunxspex_fitting/io.py
@@ -1,10 +1,9 @@
 """
 The ``io`` module contains code to read instrument specific spectral data.
 """
-from astropy.io import fits
 import numpy as np
 
-from sunpy.io.special.genx import read_genx
+from astropy.io import fits
 
 __all__ = ["_read_pha", "_read_arf", "_read_rmf", "_read_rhessi_spec_file", "_read_rhessi_srm_file",
            "_read_stix_spec_file", "_read_stix_srm_file"]
@@ -154,10 +153,10 @@ def _read_stix_srm_file(srm_file):
     with fits.open(srm_file) as hdul:
         d0 = hdul[1].header
         d1 = hdul[1].data
-        d2 = hdul[2].header
         d3 = hdul[2].data
-    pcb = np.concatenate((d1['ENERG_LO'][:,None],d1['ENERG_HI'][:,None]), axis=1)
-    
-    return {"photon_energy_bin_edges": pcb, 
-            "count_energy_bin_edges": np.concatenate((d3['E_MIN'][:,None],d3['E_MAX'][:,None]), axis=1),
+
+    pcb = np.concatenate((d1['ENERG_LO'][:, None], d1['ENERG_HI'][:, None]), axis=1)
+
+    return {"photon_energy_bin_edges": pcb,
+            "count_energy_bin_edges": np.concatenate((d3['E_MIN'][:, None], d3['E_MAX'][:, None]), axis=1),
             "drm": d1['MATRIX']*d0["GEOAREA"]}

--- a/sunxspex/sunxspex_fitting/stix_spec_code.py
+++ b/sunxspex/sunxspex_fitting/stix_spec_code.py
@@ -28,8 +28,8 @@ def _get_spec_file_info(spec_file):
     """
     sdict = io._read_stix_spec_file(spec_file)
 
-    times_mids = sdict["2"][1]["time"]  # mid-times of spectra, entries -> times. Mid-times from start of observation
-    time_deltas = sdict["2"][1]["timedel"]  # times deltas of spectra, entries -> times
+    times_mids = _ds_times2s_times(sdict["2"][1]["time"])   # mid-times of spectra, entries -> times. Mid-times from start of observation
+    time_deltas = _ds_times2s_times(sdict["2"][1]["timedel"]) # times deltas of spectra, entries -> times
     time_diff_so2e = sdict["0"][0]["EAR_TDEL"]  # time difference between Sun2Earth and Sun2SO, so time at earth for measurement is this difference added on to the actual detection time
     # spectrum number in the file, entries -> times # spec_num = sdict["1"][1]["SPEC_NUM"]
 
@@ -40,8 +40,8 @@ def _get_spec_file_info(spec_file):
     _plus_half_bin_width = np.ceil(time_deltas/2)
     t_hi = times_mids + _plus_half_bin_width
 
-    spec_stimes = [Time(sdict["0"][0]["DATE_BEG"], format='isot', scale='utc')+TimeDelta(time_diff_so2e * u.s)+TimeDelta(dt * u.ds) for dt in t_lo]
-    spec_etimes = [Time(sdict["0"][0]["DATE_BEG"], format='isot', scale='utc')+TimeDelta(time_diff_so2e * u.s)+TimeDelta(dt * u.ds) for dt in t_hi]
+    spec_stimes = [Time(sdict["0"][0]["DATE-BEG"], format='isot', scale='utc')+TimeDelta(time_diff_so2e * u.s)+TimeDelta(dt * u.s) for dt in t_lo]
+    spec_etimes = [Time(sdict["0"][0]["DATE-BEG"], format='isot', scale='utc')+TimeDelta(time_diff_so2e * u.s)+TimeDelta(dt * u.s) for dt in t_hi]
     time_bins = np.concatenate((np.array(spec_stimes)[:, None], np.array(spec_etimes)[:, None]), axis=1)
 
     channel_bins_inds, channel_bins = _return_masked_bins(sdict)
@@ -66,7 +66,7 @@ def _ds_times2s_times(ds_times):
     -------
     A 2d array of the time bin edges.
     """
-    return ds_times
+    return ds_times * (10**(-2))
 
 
 def _return_masked_bins(sdict):
@@ -85,9 +85,9 @@ def _return_masked_bins(sdict):
     e_bins = np.concatenate((sdict["4"][1]['e_low'][:, None], sdict["4"][1]['e_high'][:, None]), axis=1)
 
     # get all indices of the energy bins needed
-    mask_inds = sdict["1"][1]['energy_bin_mask'][0].astype(bool)
+    mask_inds = sdict["1"][1]['energy_bin_edge_mask'][0].astype(bool)
 
-    return mask_inds, e_bins[mask_inds]
+    return mask_inds, e_bins
 
 
 def _spec_file_units_check(stix_dict, time_dels):
@@ -110,7 +110,7 @@ def _spec_file_units_check(stix_dict, time_dels):
     """
     # stix can be saved out with counts, counts/sec, or counts/sec/cm^2/keV using counts, rate, or flux, respectively
     if stix_dict["0"][0]["BUNIT"] == "counts":
-        counts = stix_dict["2"][1]["counts"][:, 1:]
+        counts = stix_dict["2"][1]["counts"][:, :]
         counts_err = np.sqrt(counts)  # should this be added in quadrature to the estimated count compression error
         cts_rates = counts / time_dels[:, None]
         cts_rate_err = counts_err / time_dels[:, None]
@@ -149,3 +149,5 @@ def _get_srm_file_info(srm_file):
     srm = srm * np.diff(channel_bins, axis=1).flatten()
 
     return photon_bins, channel_bins, srm
+    
+    

--- a/sunxspex/sunxspex_fitting/stix_spec_code.py
+++ b/sunxspex/sunxspex_fitting/stix_spec_code.py
@@ -29,7 +29,7 @@ def _get_spec_file_info(spec_file):
     sdict = io._read_stix_spec_file(spec_file)
 
     times_mids = _ds_times2s_times(sdict["2"][1]["time"])   # mid-times of spectra, entries -> times. Mid-times from start of observation
-    time_deltas = _ds_times2s_times(sdict["2"][1]["timedel"]) # times deltas of spectra, entries -> times
+    time_deltas = _ds_times2s_times(sdict["2"][1]["timedel"])  # times deltas of spectra, entries -> times
     time_diff_so2e = sdict["0"][0]["EAR_TDEL"]  # time difference between Sun2Earth and Sun2SO, so time at earth for measurement is this difference added on to the actual detection time
     # spectrum number in the file, entries -> times # spec_num = sdict["1"][1]["SPEC_NUM"]
 
@@ -149,5 +149,3 @@ def _get_srm_file_info(srm_file):
     srm = srm * np.diff(channel_bins, axis=1).flatten()
 
     return photon_bins, channel_bins, srm
-    
-    

--- a/sunxspex/sunxspex_fitting/stix_spec_code.py
+++ b/sunxspex/sunxspex_fitting/stix_spec_code.py
@@ -28,8 +28,8 @@ def _get_spec_file_info(spec_file):
     """
     sdict = io._read_stix_spec_file(spec_file)
 
-    times_mids = _ds_times2s_times(sdict["2"][1]["time"])   # mid-times of spectra, entries -> times. Mid-times from start of observation
-    time_deltas = _ds_times2s_times(sdict["2"][1]["timedel"])  # times deltas of spectra, entries -> times
+    times_mids = sdict["2"][1]["time"]  # mid-times of spectra, entries -> times. Mid-times from start of observation
+    time_deltas = sdict["2"][1]["timedel"]  # times deltas of spectra, entries -> times
     time_diff_so2e = sdict["0"][0]["EAR_TDEL"]  # time difference between Sun2Earth and Sun2SO, so time at earth for measurement is this difference added on to the actual detection time
     # spectrum number in the file, entries -> times # spec_num = sdict["1"][1]["SPEC_NUM"]
 
@@ -40,8 +40,8 @@ def _get_spec_file_info(spec_file):
     _plus_half_bin_width = np.ceil(time_deltas/2)
     t_hi = times_mids + _plus_half_bin_width
 
-    spec_stimes = [Time(sdict["0"][0]["DATE-BEG"], format='isot', scale='utc')+TimeDelta(time_diff_so2e * u.s)+TimeDelta(dt * u.s) for dt in t_lo]
-    spec_etimes = [Time(sdict["0"][0]["DATE-BEG"], format='isot', scale='utc')+TimeDelta(time_diff_so2e * u.s)+TimeDelta(dt * u.s) for dt in t_hi]
+    spec_stimes = [Time(sdict["0"][0]["DATE-BEG"], format='isot', scale='utc')+TimeDelta(time_diff_so2e * u.s)+TimeDelta(dt * u.cs) for dt in t_lo]
+    spec_etimes = [Time(sdict["0"][0]["DATE-BEG"], format='isot', scale='utc')+TimeDelta(time_diff_so2e * u.s)+TimeDelta(dt * u.cs) for dt in t_hi]
     time_bins = np.concatenate((np.array(spec_stimes)[:, None], np.array(spec_etimes)[:, None]), axis=1)
 
     channel_bins_inds, channel_bins = _return_masked_bins(sdict)
@@ -52,21 +52,6 @@ def _get_spec_file_info(spec_file):
     counts, counts_err, cts_rates, cts_rate_err = _spec_file_units_check(stix_dict=sdict, time_dels=time_deltas)
 
     return channel_bins, channel_bins_inds, time_bins, lvt, counts, counts_err, cts_rates, cts_rate_err
-
-
-def _ds_times2s_times(ds_times):
-    """ STIX time might be in ds (deci-seconds). Convert to seconds.
-
-    Parameters
-    ----------
-    ds_times : time bins
-            A 2D array of time bins.
-
-    Returns
-    -------
-    A 2d array of the time bin edges.
-    """
-    return ds_times * (10**(-2))
 
 
 def _return_masked_bins(sdict):

--- a/sunxspex/sunxspex_fitting/tests/test_io.py
+++ b/sunxspex/sunxspex_fitting/tests/test_io.py
@@ -112,9 +112,9 @@ def test_read_stix_srm_file(mock_open):
     drm = 2*np.eye(2)
 
     hdul = []
-    headers = [{}, {'GEOAREA':2}, {}]
-    data = [{}, {'MATRIX': np.eye(2), 'ENERG_LO':np.array([1, 2]), 'ENERG_HI': np.array([2, 3])}, {'E_MIN':np.array([2, 3]), 'E_MAX':np.array([3, 4])}]
-    
+    headers = [{}, {'GEOAREA': 2}, {}]
+    data = [{}, {'MATRIX': np.eye(2), 'ENERG_LO': np.array([1, 2]), 'ENERG_HI': np.array([2, 3])}, {'E_MIN': np.array([2, 3]), 'E_MAX':np.array([3, 4])}]
+
     for i in range(len(headers)):
         m = MagicMock()
         m.header = headers[i]


### PR DESCRIPTION
This PR fixes the functions for handling STIX spectral and SRM files, this means that the Sunxspex class will be apple to correctly load in the new/final version of STIX files. I'm mainly fixing formatting of keywords and data, change of time units, format of energy bins and counts that are given in the spectral files. I have also fixed the incorrect plotting of background and event time-ranges for STIX lightcurves and spectrograms (examples in issue #97). 
