### PR TITLE
Photon space power law

### DIFF
--- a/changelog/102.feature.rst
+++ b/changelog/102.feature.rst
@@ -1,0 +1,6 @@
+Add photon space broken power law.
+Behavior is equivalent to the OSPEX power law
+when the pivot option is given.
+Similar to XSPEC bknpower.
+
+See the pull request for more details.

--- a/sunxspex/__init__.py
+++ b/sunxspex/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-from .version import __version__
+# from .version import __version__
 
 __all__ = []
 from . import io, sunxspex_fitting, thermal

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -1,0 +1,98 @@
+import functools
+
+import astropy.units as u
+import numpy as np
+
+PHOTON_RATE_UNIT = u.ph / u.keV / u.cm**2 / u.s
+
+@u.quantity_input
+def power_law_integral(
+    energy: u.keV,
+    norm_energy: u.keV,
+    norm: PHOTON_RATE_UNIT,
+    index: u.one
+) -> (PHOTON_RATE_UNIT * u.keV):
+    """Evaluate the antiderivative of a power law at a given energy.
+
+    :param energy: Array of energies to evaluate.
+    :type energy: u.keV
+    :param norm_energy: Normalization energy.
+    :param norm: Function normalization.
+    :param index: Power law index.
+    :return: Antiderivative of power law evaluated at given energies.
+    :rtype: PHOTON_RATE_UNIT
+    """
+    prefactor = norm * norm_energy
+    arg = energy / norm_energy
+    if index == 1:
+        return prefactor * np.log(arg)
+    return prefactor * arg**(1 - index) / (1 - index)
+
+
+@u.quantity_input
+def broken_power_law_binned_flux(
+    energy_edges: u.keV,
+    reference_energy: u.keV,
+    reference_flux: PHOTON_RATE_UNIT,
+    break_energy: u.keV,
+    lower_index: u.one,
+    upper_index: u.one
+) -> PHOTON_RATE_UNIT:
+    """Analytically evaluate a photon-space broken power law.
+
+    :param energy_edges: 1D array of energy edges.
+    :type energy_edges: u.keV
+    :param reference_energy: Normalization energy.
+    :type reference_energy: u.keV
+    :param reference_flux: Normalization flux.
+    :type reference_flux: PHOTON_RATE_UNIT
+    :param break_energy: Power law break energy.
+    :type break_energy: u.keV
+    :param lower_index: Power law index below the break.
+    :type lower_index: u.one
+    :param upper_index: Power law index above the break.
+    :type upper_index: u.one
+    :return: Photon flux of the broken power law.
+    :rtype: PHOTON_RATE_UNIT
+    """
+    norm_idx = lower_index if reference_energy <= break_energy else upper_index
+    # norm is from continuity at break energy and solving.
+    norm = reference_flux * (reference_energy / break_energy)**(norm_idx)
+
+    cnd = energy_edges <= break_energy
+    lower = energy_edges[cnd]
+    upper = energy_edges[~cnd]
+
+    up_integ = functools.partial(
+        power_law_integral,
+        norm_energy=break_energy,
+        norm=norm,
+        index=upper_index
+    )
+    low_integ = functools.partial(
+        power_law_integral,
+        norm_energy=break_energy,
+        norm=norm,
+        index=lower_index
+    )
+
+    lower_portion = low_integ(energy=lower[1:])
+    lower_portion -= low_integ(energy=lower[:-1])
+
+    upper_portion = up_integ(energy=upper[1:])
+    upper_portion -= up_integ(energy=upper[:-1])
+
+    twixt_portion = []
+    # bin between the portions is comprised of both power laws
+    if lower.size > 0 and upper.size > 0:
+        twixt_portion = np.diff(
+            low_integ(energy=np.array([break_energy.value, upper[0].value]) << u.keV)
+        )
+        twixt_portion += np.diff(
+            up_integ(energy=np.array([lower[-1].value, break_energy.value]) << u.keV)
+        )
+
+    ret = np.concatenate((lower_portion, twixt_portion, upper_portion))
+    assert ret.size == (energy_edges.size - 1)
+    # go back to units of cm2/sec/keV
+    return ret / np.diff(energy_edges)

--- a/sunxspex/tests/test_photon_power_law.py
+++ b/sunxspex/tests/test_photon_power_law.py
@@ -1,0 +1,33 @@
+import astropy.units as u
+from matplotlib import pyplot as plt
+import numpy as np
+
+from sunxspex import photon_power_law as ppl
+
+
+''' i know this isn't really a test but it shows that things are working '''
+
+def basic_plot_test():
+    paramz = dict()
+    paramz['energy_edges'] = (edges := np.logspace(0, 2, num=40) << u.keV)
+    paramz['reference_energy'] = 50 << u.keV
+    paramz['reference_flux'] = 10 << ppl.PHOTON_RATE_UNIT
+    paramz['break_energy'] = 20 << u.keV
+    paramz['lower_index'] = 1
+    paramz['upper_index'] = 6
+
+    flux = ppl.broken_power_law_binned_flux(**paramz)
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.stairs(flux.value, edges.value)
+    ax.set(
+        xlabel=edges.unit,
+        ylabel=flux.unit,
+        xscale='log',
+        yscale='log',
+        title='Broken power law'
+    )
+    plt.show()
+
+if __name__ == '__main__':
+    basic_plot_test()


### PR DESCRIPTION
## PR Description
Adds photon space broken power law.

Compare with [f_bpow](https://ips.ucsd.edu/help/ssw/packages_f.html#F_BPOW) and [bknpower](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/node142.html).

The broken power law bins flux properly and uses an analytical antiderivative of a power law to do so.
The documentation is (mostly?) in line with other stuff I've seen in sunxspex so far.
Needs more tests!

Fixes #101 