### PR TITLE
Photon power law

### DIFF
--- a/changelog/103.feature.rst
+++ b/changelog/103.feature.rst
@@ -1,1 +1,1 @@
-Add photon space broken power law, located in `sunxspex/photon_power_law.py`, function name `broken_power_law_binned_flux`. Behavior is equivalent to the OSPEX power law when the pivot option is given. Similar to XSPEC bknpower. See the pull request for more details.
+Add photon space broken power law :func:`sunxspex.photon_power_law.broken_power_law_binned_flux`. Behavior is equivalent to the OSPEX power law when the pivot option is given. Similar to XSPEC bknpower.

--- a/changelog/103.feature.rst
+++ b/changelog/103.feature.rst
@@ -1,1 +1,1 @@
-Add photon space broken power law :func:`sunxspex.photon_power_law.broken_power_law_binned_flux`. Behavior is equivalent to the OSPEX power law when the pivot option is given. Similar to XSPEC bknpower.
+Add photon space broken power law :func:`sunxspex.photon_power_law.broken_power_law_binned_flux`. Behavior is equivalent to the OSPEX power law f_bpow.pro when the pivot option is given. Similar to XSPEC bknpower.

--- a/changelog/103.feature.rst
+++ b/changelog/103.feature.rst
@@ -1,0 +1,6 @@
+Add photon space broken power law.
+Behavior is equivalent to the OSPEX power law
+when the pivot option is given.
+Similar to XSPEC bknpower.
+
+See the pull request for more details.

--- a/changelog/103.feature.rst
+++ b/changelog/103.feature.rst
@@ -1,6 +1,1 @@
-Add photon space broken power law.
-Behavior is equivalent to the OSPEX power law
-when the pivot option is given.
-Similar to XSPEC bknpower.
-
-See the pull request for more details.
+Add photon space broken power law, located in `sunxspex/photon_power_law.py`, function name `broken_power_law_binned_flux`. Behavior is equivalent to the OSPEX power law when the pivot option is given. Similar to XSPEC bknpower. See the pull request for more details.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -12,3 +12,4 @@ Software and API.
 .. automodapi:: sunxspex.constants
 .. automodapi:: sunxspex.sunxspex_fitting
 .. automodapi:: sunxspex.sunxspex_fitting.io
+.. automodapi:: sunxspex.photon_power_law

--- a/sunxspex/__init__.py
+++ b/sunxspex/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-from .version import __version__
+# from .version import __version__
 
 __all__ = []
 from . import io, sunxspex_fitting, thermal

--- a/sunxspex/__init__.py
+++ b/sunxspex/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-# from .version import __version__
+from .version import __version__
 
 __all__ = []
 from . import io, sunxspex_fitting, thermal

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -150,7 +150,7 @@ def power_law_binned_flux(
     reference_flux: PHOTON_RATE_UNIT,
     index: u.one
 ) -> PHOTON_RATE_UNIT:
-    '''Single power law, defined by setting the break energy to -inf and the lower index to nan.
+    r'''Single power law, defined by setting the break energy to -inf and the lower index to nan.
 
     See docstring of `broken_power_law_binned_flux` for more details.
 

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -1,7 +1,8 @@
 import functools
 
-import astropy.units as u
 import numpy as np
+
+import astropy.units as u
 
 PHOTON_RATE_UNIT = u.ph / u.keV / u.cm**2 / u.s
 

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -25,6 +25,25 @@ def power_law_integral(
 
 
 @u.quantity_input
+def broken_power_law_normalizations(
+    reference_flux: PHOTON_RATE_UNIT,
+    reference_energy: u.keV,
+    break_energy: u.keV,
+    lower_index: u.one,
+    upper_index: u.one
+) -> PHOTON_RATE_UNIT:
+    ''' give the correct upper and lower power law normalizations given the desired flux and locations of break & norm energies '''
+    eng_arg = (break_energy / reference_energy).to(u.one)
+    if reference_energy < break_energy:
+        low_norm = reference_flux
+        up_norm = reference_flux * eng_arg**(upper_index - lower_index)
+    else:
+        up_norm = reference_flux
+        low_norm = reference_flux * eng_arg**(lower_index - upper_index)
+    return u.Quantity((up_norm, low_norm))
+
+
+@u.quantity_input
 def broken_power_law_binned_flux(
     energy_edges: u.keV,
     reference_energy: u.keV,
@@ -36,13 +55,14 @@ def broken_power_law_binned_flux(
     """Analytically evaluate a photon-space broken power law.
     """
 
-    eng_arg = (break_energy / reference_energy).to(u.one)
-    if reference_energy < break_energy:
-        low_norm = reference_flux
-        up_norm = reference_flux * eng_arg**(upper_index - lower_index)
-    else:
-        up_norm = reference_flux
-        low_norm = reference_flux * eng_arg**(lower_index - upper_index)
+    if energy_edges.size <= 1:
+        raise ValueError('Need at least two energy edges.')
+    if reference_flux == 0:
+        return np.zeros(energy_edges.size - 1) << PHOTON_RATE_UNIT
+
+    up_norm, low_norm = broken_power_law_normalizations(
+        reference_flux, reference_energy, break_energy, lower_index, upper_index
+    )
 
     cnd = energy_edges < break_energy
     lower = energy_edges[cnd]
@@ -61,15 +81,11 @@ def broken_power_law_binned_flux(
         index=lower_index
     )
 
-    lower_portion = low_integ(energy=lower[1:])
-    lower_portion -= low_integ(energy=lower[:-1])
-
-    upper_portion = up_integ(energy=upper[1:])
-    upper_portion -= up_integ(energy=upper[:-1])
+    lower_portion = low_integ(energy=lower[1:]) - low_integ(energy=lower[:-1])
+    upper_portion = up_integ(energy=upper[1:]) - up_integ(energy=upper[:-1])
 
     twixt_portion = []
     # bin between the portions is comprised of both power laws
-    # import pdb; pdb.set_trace()
     if lower.size > 0 and upper.size > 0:
         twixt_portion = np.diff(
             low_integ(energy=u.Quantity([lower[-1], break_energy]))
@@ -78,9 +94,30 @@ def broken_power_law_binned_flux(
             up_integ(energy=u.Quantity([break_energy, upper[0]]))
         )
 
+
     ret = np.concatenate((lower_portion, twixt_portion, upper_portion))
     if ret.size != (energy_edges.size - 1):
         raise ValueError('Bin or edge size mismatch. Bug?')
 
     # go back to units of cm2/sec/keV
     return ret / np.diff(energy_edges)
+
+
+@u.quantity_input
+def power_law_binned_flux(
+    energy_edges: u.keV,
+    reference_energy: u.keV,
+    reference_flux: PHOTON_RATE_UNIT,
+    index: u.one
+) -> PHOTON_RATE_UNIT:
+    '''
+    Single power law, defined by setting the break energy to -inf and the lower index to nan.
+    '''
+    return broken_power_law_binned_flux(
+        energy_edges=energy_edges,
+        reference_energy=reference_energy,
+        reference_flux=reference_flux,
+        break_energy=-np.inf << u.keV,
+        lower_index=np.nan,
+        upper_index=index
+    )

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -139,7 +139,6 @@ def broken_power_law_binned_flux(
             up_integ(energy=u.Quantity([break_energy, upper[0]]))
         )
 
-
     ret = np.concatenate((lower_portion, twixt_portion, upper_portion))
     if ret.size != (energy_edges.size - 1):
         raise ValueError('Bin or edge size mismatch. Bug?')

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -95,6 +95,8 @@ def broken_power_law_binned_flux(
         )
 
     ret = np.concatenate((lower_portion, twixt_portion, upper_portion))
-    assert ret.size == (energy_edges.size - 1)
+    if ret.size != (energy_edges.size - 1):
+        raise ValueError('Bin or edge size mismatch. Bug?')
+
     # go back to units of cm2/sec/keV
     return ret / np.diff(energy_edges)

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -17,8 +17,7 @@ def power_law_integral(
     r"""Evaluate the antiderivative of a power law at a given energy or vector of energies.
 
     The power law antiderivative evaluated by this function is assumed to take the following form:
-    .. math::
-        f(E) = N \left( \frac{E}{E_0} \right)^{- \gamma},
+    .. math:: f(E) = N \left( \frac{E}{E_0} \right)^{- \gamma},
 
     where $E$ is the energy, $N$ is the normalization, $E_0$ is the normalization energy,
     and $\gamma$ is the power law index.
@@ -63,9 +62,8 @@ def broken_power_law_binned_flux(
     """Analytically evaluate a photon-space broken power law and bin the flux.
 
     The broken power law is assumed to take the following form:
-    .. math::
-        f(E \le E_b) = N_1 \left( \frac{E}{E_0} \right)^{-\gamma_1},\\
-        f(E > E_b) = N_2 \left( \frac{E}{E_0} \right)^{-\gamma_2}
+    .. math:: f(E \le E_b) = N_1 \left( \frac{E}{E_0} \right)^{-\gamma_1},
+    .. math:: f(E > E_b) = N_2 \left( \frac{E}{E_0} \right)^{-\gamma_2}
 
     where $E$ is the energy, $N_1$ and $N_2$ are the normalization below and above the break,
     $E_0$ is the normalization energy, $E_b$ is the break energy, and $\gamma_1$ and $\gamma_2$ are the upper and lower

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -16,26 +16,26 @@ def power_law_integral(
 ) -> (PHOTON_RATE_UNIT * u.keV):
     r"""Evaluate the antiderivative of a power law at a given energy or vector of energies.
 
-    The power law antiderivative evaluated by this function is assumed to take the following form:
-    .. math:: f(E) = N \left( \frac{E}{E_0} \right)^{- \gamma},
-    where $E$ is the energy, $N$ is the normalization, $E_0$ is the normalization energy,
-    and $\gamma$ is the power law index.
+    The power law antiderivative evaluated by this function is assumed to take the following form,
+    :math: `f(E) = N \left( \frac{E}{E_0} \right)^{- \gamma}`,
+    where :math:`E` is the energy, :math:`N` is the normalization, :math:`E_0` is the normalization energy,
+    and :math:`\gamma` is the power law index.
 
-    The value of $\gamma$ is assumed to be positive, but the functional form
+    The value of :math:`\gamma` is assumed to be positive, but the functional form
     includes a negative sign.
 
-    The special case of $\gamma = 1$ is handled.
+    The special case of :math:`\gamma = 1` is handled.
 
     Parameters
     ----------
     energy : `astropy.units.Quantity`
-        Energy (or vector of energies) at which to evaluate the power law antiderivative, i.e. $E$.
+        Energy (or vector of energies) at which to evaluate the power law antiderivative.
     norm_energy : `astropy.units.Quantity`
-        Energy used for the normalization of the power law argument, i.e. $E_0$.
+        Energy used for the normalization of the power law argument, i.e. :math:`E_0`.
     norm : `astropy.units.Quantity`
-        Normalization of the power law integral, i.e. $N$, in units convertible to ph / (cm2 . keV . s).
+        Normalization of the power law integral, i.e. :math:`N`, in units convertible to ph / (cm2 . keV . s).
     index : `astropy.units.Quantity`
-        The power law index, i.e. $\gamma$.
+        The power law index, i.e. :math:`\gamma`.
 
     Returns
     -------
@@ -58,19 +58,19 @@ def broken_power_law_binned_flux(
     lower_index: u.one,
     upper_index: u.one
 ) -> PHOTON_RATE_UNIT:
-    """Analytically evaluate a photon-space broken power law and bin the flux.
+    r"""Analytically evaluate a photon-space broken power law and bin the flux.
 
-    The broken power law is assumed to take the following form:
-    .. math:: f(E \le E_b) = N_1 \left( \frac{E}{E_0} \right)^{-\gamma_1},
-    .. math:: f(E > E_b) = N_2 \left( \frac{E}{E_0} \right)^{-\gamma_2}
-    where $E$ is the energy, $N_1$ and $N_2$ are the normalization below and above the break,
-    $E_0$ is the normalization energy, $E_b$ is the break energy, and $\gamma_1$ and $\gamma_2$ are the upper and lower
+    The broken power law is assumed to take the following form,
+    :math:`f(E \le E_b) &= N_1 \left( \frac{E}{E_0} \right)^{-\gamma_1}`,
+    :math:`f(E > E_b)   &= N_2 \left( \frac{E}{E_0} \right)^{-\gamma_2}`
+    where :math:`E` is the energy, :math:`N_1` and :math:`N_2` are the normalization below and above the break,
+    :math:`E_0` is the normalization energy, :math:`E_b` is the break energy, and :math:`\gamma_1` and :math:`\gamma_2` are the upper and lower
     power law indices.
 
     Only one normalization flux and energy are given. Continuity is enforced at the break energy
     so that the normalization is correct at the chosen energy.
 
-    The values of $\gamma_1$ and $\gamma_2$ are assumed to be positive, but the functional form
+    The values of :math:`\gamma_11 and :math:`\gamma_21 are assumed to be positive, but the functional form
     includes negative signs.
 
     Parameters
@@ -78,7 +78,7 @@ def broken_power_law_binned_flux(
     energy_edges : `astropy.units.Quantity`
         1D array of energy edges defining the energy bins.
     reference_energy : `astropy.units.Quantity`
-        Energy at which the normalization is applied, i.e. $E_0$.
+        Energy at which the normalization is applied, i.e. :math:`E_0`.
     reference_flux : `astropy.units.Quantity`
         Normalization flux for the photon power law.
     break_energy : `astropy.units.Quantity`
@@ -152,14 +152,12 @@ def power_law_binned_flux(
 ) -> PHOTON_RATE_UNIT:
     r'''Single power law, defined by setting the break energy to -inf and the lower index to nan.
 
-    See docstring of `broken_power_law_binned_flux` for more details.
-
     Parameters
     ----------
     energy_edges : `astropy.units.Quantity`
         1D array of energy edges defining the energy bins.
     reference_energy : `astropy.units.Quantity`
-        Energy at which the normalization is applied, i.e. $E_0$.
+        Energy at which the normalization is applied, i.e. :math:`E_0`.
     reference_flux : `astropy.units.Quantity`
         Normalization flux for the photon power law.
     index : `astropy.units.Quantity`

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -1,0 +1,98 @@
+import functools
+
+import astropy.units as u
+import numpy as np
+
+PHOTON_RATE_UNIT = u.ph / u.keV / u.cm**2 / u.s
+
+@u.quantity_input
+def power_law_integral(
+    energy: u.keV,
+    norm_energy: u.keV,
+    norm: PHOTON_RATE_UNIT,
+    index: u.one
+) -> (PHOTON_RATE_UNIT * u.keV):
+    """Evaluate the antiderivative of a power law at a given energy.
+
+    :param energy: Array of energies to evaluate.
+    :type energy: u.keV
+    :param norm_energy: Normalization energy.
+    :param norm: Function normalization.
+    :param index: Power law index.
+    :return: Antiderivative of power law evaluated at given energies.
+    :rtype: PHOTON_RATE_UNIT
+    """
+    prefactor = norm * norm_energy
+    arg = energy / norm_energy
+    if index == 1:
+        return prefactor * np.log(arg)
+    return prefactor * arg**(1 - index) / (1 - index)
+
+
+@u.quantity_input
+def broken_power_law_binned_flux(
+    energy_edges: u.keV,
+    reference_energy: u.keV,
+    reference_flux: PHOTON_RATE_UNIT,
+    break_energy: u.keV,
+    lower_index: u.one,
+    upper_index: u.one
+) -> PHOTON_RATE_UNIT:
+    """Analytically evaluate a photon-space broken power law.
+
+    :param energy_edges: 1D array of energy edges.
+    :type energy_edges: u.keV
+    :param reference_energy: Normalization energy.
+    :type reference_energy: u.keV
+    :param reference_flux: Normalization flux.
+    :type reference_flux: PHOTON_RATE_UNIT
+    :param break_energy: Power law break energy.
+    :type break_energy: u.keV
+    :param lower_index: Power law index below the break.
+    :type lower_index: u.one
+    :param upper_index: Power law index above the break.
+    :type upper_index: u.one
+    :return: Photon flux of the broken power law.
+    :rtype: PHOTON_RATE_UNIT
+    """
+    norm_idx = lower_index if reference_energy <= break_energy else upper_index
+    # norm is from continuity at break energy and solving.
+    norm = reference_flux * (reference_energy / break_energy)**(norm_idx)
+
+    cnd = energy_edges <= break_energy
+    lower = energy_edges[cnd]
+    upper = energy_edges[~cnd]
+
+    up_integ = functools.partial(
+        power_law_integral,
+        norm_energy=break_energy,
+        norm=norm,
+        index=upper_index
+    )
+    low_integ = functools.partial(
+        power_law_integral,
+        norm_energy=break_energy,
+        norm=norm,
+        index=lower_index
+    )
+
+    lower_portion = low_integ(energy=lower[1:])
+    lower_portion -= low_integ(energy=lower[:-1])
+
+    upper_portion = up_integ(energy=upper[1:])
+    upper_portion -= up_integ(energy=upper[:-1])
+
+    twixt_portion = []
+    # bin between the portions is comprised of both power laws
+    if lower.size > 0 and upper.size > 0:
+        twixt_portion = np.diff(
+            low_integ(energy=np.array([break_energy.value, upper[0].value]) << u.keV)
+        )
+        twixt_portion += np.diff(
+            up_integ(energy=np.array([lower[-1].value, break_energy.value]) << u.keV)
+        )
+
+    ret = np.concatenate((lower_portion, twixt_portion, upper_portion))
+    assert ret.size == (energy_edges.size - 1)
+    # go back to units of cm2/sec/keV
+    return ret / np.diff(energy_edges)

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -1,5 +1,7 @@
 import functools
+
 import numpy as np
+
 import astropy.units as u
 
 PHOTON_RATE_UNIT = u.ph / u.keV / u.cm**2 / u.s
@@ -83,6 +85,8 @@ def compute_broken_power_law(
         Energy at which the normalization is applied, i.e. :math:`E_0`.
     norm_flux : `astropy.units.Quantity`
         Normalization flux for the photon power law.
+        The `norm_flux` corresponds to either :math:`N_1` or :math:`N_2` depending
+        on if the energy is below or above the break.
     break_energy : `astropy.units.Quantity`
         Break energy of the broken power law. The energy bin containing the break energy
         will be a combination of the lower and upper power laws.
@@ -162,6 +166,7 @@ def compute_power_law(
         Energy at which the normalization is applied, i.e. :math:`E_0`.
     norm_flux : `astropy.units.Quantity`
         Normalization flux for the photon power law.
+        See
     index : `astropy.units.Quantity`
         Power law index.
 

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -17,7 +17,7 @@ def power_law_integral(
     r"""Evaluate the antiderivative of a power law at a given energy or vector of energies.
 
     The power law antiderivative evaluated by this function is assumed to take the following form,
-    :math: `f(E) = N \left( \frac{E}{E_0} \right)^{- \gamma}`,
+    :math:`f(E) = N \left( \frac{E}{E_0} \right)^{- \gamma}`,
     where :math:`E` is the energy, :math:`N` is the normalization, :math:`E_0` is the normalization energy,
     and :math:`\gamma` is the power law index.
 
@@ -61,8 +61,12 @@ def broken_power_law_binned_flux(
     r"""Analytically evaluate a photon-space broken power law and bin the flux.
 
     The broken power law is assumed to take the following form,
-    :math:`f(E \le E_b) &= N_1 \left( \frac{E}{E_0} \right)^{-\gamma_1}`,
-    :math:`f(E > E_b)   &= N_2 \left( \frac{E}{E_0} \right)^{-\gamma_2}`
+    
+    .. math::
+
+       f(E \le E_b) = N_1 \left( \frac{E}{E_0} \right)^{-\gamma_1} \\
+       f(E > E_b)   = N_2 \left( \frac{E}{E_0} \right)^{-\gamma_2}
+
     where :math:`E` is the energy, :math:`N_1` and :math:`N_2` are the normalization below and above the break,
     :math:`E_0` is the normalization energy, :math:`E_b` is the break energy, and :math:`\gamma_1` and :math:`\gamma_2` are the upper and lower
     power law indices.
@@ -70,7 +74,7 @@ def broken_power_law_binned_flux(
     Only one normalization flux and energy are given. Continuity is enforced at the break energy
     so that the normalization is correct at the chosen energy.
 
-    The values of :math:`\gamma_11 and :math:`\gamma_21 are assumed to be positive, but the functional form
+    The values of :math:`\gamma_1` and :math:`\gamma_2` are assumed to be positive, but the functional form
     includes negative signs.
 
     Parameters

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -61,7 +61,7 @@ def broken_power_law_binned_flux(
     r"""Analytically evaluate a photon-space broken power law and bin the flux.
 
     The broken power law is assumed to take the following form,
-    
+
     .. math::
 
        f(E \le E_b) = N_1 \left( \frac{E}{E_0} \right)^{-\gamma_1} \\

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -18,7 +18,6 @@ def power_law_integral(
 
     The power law antiderivative evaluated by this function is assumed to take the following form:
     .. math:: f(E) = N \left( \frac{E}{E_0} \right)^{- \gamma},
-
     where $E$ is the energy, $N$ is the normalization, $E_0$ is the normalization energy,
     and $\gamma$ is the power law index.
 
@@ -64,7 +63,6 @@ def broken_power_law_binned_flux(
     The broken power law is assumed to take the following form:
     .. math:: f(E \le E_b) = N_1 \left( \frac{E}{E_0} \right)^{-\gamma_1},
     .. math:: f(E > E_b) = N_2 \left( \frac{E}{E_0} \right)^{-\gamma_2}
-
     where $E$ is the energy, $N_1$ and $N_2$ are the normalization below and above the break,
     $E_0$ is the normalization energy, $E_b$ is the break energy, and $\gamma_1$ and $\gamma_2$ are the upper and lower
     power law indices.

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -14,33 +14,41 @@ def power_law_integral(
     norm: PHOTON_RATE_UNIT,
     index: u.one
 ) -> (PHOTON_RATE_UNIT * u.keV):
-    """Evaluate the antiderivative of a power law at a given energy,
-       or vector of energies.
+    r"""Evaluate the antiderivative of a power law at a given energy or vector of energies.
+
+    The power law antiderivative evaluated by this function is assumed to take the following form:
+    .. math::
+        f(E) = N \left( \frac{E}{E_0} \right)^{- \gamma},
+
+    where $E$ is the energy, $N$ is the normalization, $E_0$ is the normalization energy,
+    and $\gamma$ is the power law index.
+
+    The value of $\gamma$ is assumed to be positive, but the functional form
+    includes a negative sign.
+
+    The special case of $\gamma = 1$ is handled.
+
+    Parameters
+    ----------
+    energy : `astropy.units.Quantity`
+        Energy (or vector of energies) at which to evaluate the power law antiderivative, i.e. $E$.
+    norm_energy : `astropy.units.Quantity`
+        Energy used for the normalization of the power law argument, i.e. $E_0$.
+    norm : `astropy.units.Quantity`
+        Normalization of the power law integral, i.e. $N$, in units convertible to ph / (cm2 . keV . s).
+    index : `astropy.units.Quantity`
+        The power law index, i.e. $\gamma$.
+
+    Returns
+    -------
+    `astropy.units.Quantity`
+        Analytical antiderivative of a power law evaluated at the given energies.
     """
     prefactor = norm * norm_energy
     arg = (energy / norm_energy).to(u.one)
     if index == 1:
         return prefactor * np.log(arg)
     return (prefactor / (1 - index)) * arg**(1 - index)
-
-
-@u.quantity_input
-def broken_power_law_normalizations(
-    reference_flux: PHOTON_RATE_UNIT,
-    reference_energy: u.keV,
-    break_energy: u.keV,
-    lower_index: u.one,
-    upper_index: u.one
-) -> PHOTON_RATE_UNIT:
-    ''' give the correct upper and lower power law normalizations given the desired flux and locations of break & norm energies '''
-    eng_arg = (break_energy / reference_energy).to(u.one)
-    if reference_energy < break_energy:
-        low_norm = reference_flux
-        up_norm = reference_flux * eng_arg**(upper_index - lower_index)
-    else:
-        up_norm = reference_flux
-        low_norm = reference_flux * eng_arg**(lower_index - upper_index)
-    return u.Quantity((up_norm, low_norm))
 
 
 @u.quantity_input
@@ -52,7 +60,44 @@ def broken_power_law_binned_flux(
     lower_index: u.one,
     upper_index: u.one
 ) -> PHOTON_RATE_UNIT:
-    """Analytically evaluate a photon-space broken power law.
+    """Analytically evaluate a photon-space broken power law and bin the flux.
+
+    The broken power law is assumed to take the following form:
+    .. math::
+        f(E \le E_b) = N_1 \left( \frac{E}{E_0} \right)^{-\gamma_1},\\
+        f(E > E_b) = N_2 \left( \frac{E}{E_0} \right)^{-\gamma_2}
+
+    where $E$ is the energy, $N_1$ and $N_2$ are the normalization below and above the break,
+    $E_0$ is the normalization energy, $E_b$ is the break energy, and $\gamma_1$ and $\gamma_2$ are the upper and lower
+    power law indices.
+
+    Only one normalization flux and energy are given. Continuity is enforced at the break energy
+    so that the normalization is correct at the chosen energy.
+
+    The values of $\gamma_1$ and $\gamma_2$ are assumed to be positive, but the functional form
+    includes negative signs.
+
+    Parameters
+    ----------
+    energy_edges : `astropy.units.Quantity`
+        1D array of energy edges defining the energy bins.
+    reference_energy : `astropy.units.Quantity`
+        Energy at which the normalization is applied, i.e. $E_0$.
+    reference_flux : `astropy.units.Quantity`
+        Normalization flux for the photon power law.
+    break_energy : `astropy.units.Quantity`
+        Break energy of the broken power law. The energy bin containing the break energy
+        will be a combination of the lower and upper power laws.
+    lower_index : `astropy.units.Quantity`
+        Lower power law index.
+    upper_index : `astropy.units.Quantity`
+        Upper power law index.
+
+    Returns
+    -------
+    `astropy.units.Quantity`
+        Photon broken power law, where the flux in each energy bin is equal
+        to the broken power law analytically averaged over each bin.
     """
 
     if energy_edges.size <= 1:
@@ -60,7 +105,7 @@ def broken_power_law_binned_flux(
     if reference_flux == 0:
         return np.zeros(energy_edges.size - 1) << PHOTON_RATE_UNIT
 
-    up_norm, low_norm = broken_power_law_normalizations(
+    up_norm, low_norm = _broken_power_law_normalizations(
         reference_flux, reference_energy, break_energy, lower_index, upper_index
     )
 
@@ -110,8 +155,27 @@ def power_law_binned_flux(
     reference_flux: PHOTON_RATE_UNIT,
     index: u.one
 ) -> PHOTON_RATE_UNIT:
-    '''
-    Single power law, defined by setting the break energy to -inf and the lower index to nan.
+    '''Single power law, defined by setting the break energy to -inf and the lower index to nan.
+
+    See docstring of `broken_power_law_binned_flux` for more details.
+
+    Parameters
+    ----------
+    energy_edges : `astropy.units.Quantity`
+        1D array of energy edges defining the energy bins.
+    reference_energy : `astropy.units.Quantity`
+        Energy at which the normalization is applied, i.e. $E_0$.
+    reference_flux : `astropy.units.Quantity`
+        Normalization flux for the photon power law.
+    index : `astropy.units.Quantity`
+        Power law index.
+
+    Returns
+    -------
+    `astropy.units.Quantity`
+        Photon power law, where the flux in each energy bin is equal
+        to the power law analytically averaged over each bin.
+
     '''
     return broken_power_law_binned_flux(
         energy_edges=energy_edges,
@@ -121,3 +185,25 @@ def power_law_binned_flux(
         lower_index=np.nan,
         upper_index=index
     )
+
+
+@u.quantity_input
+def _broken_power_law_normalizations(
+    reference_flux: PHOTON_RATE_UNIT,
+    reference_energy: u.keV,
+    break_energy: u.keV,
+    lower_index: u.one,
+    upper_index: u.one
+) -> PHOTON_RATE_UNIT:
+    '''(internal)
+    give the correct upper and lower power law normalizations given the
+    desired flux and locations of break & norm energies
+    '''
+    eng_arg = (break_energy / reference_energy).to(u.one)
+    if reference_energy < break_energy:
+        low_norm = reference_flux
+        up_norm = reference_flux * eng_arg**(upper_index - lower_index)
+    else:
+        up_norm = reference_flux
+        low_norm = reference_flux * eng_arg**(lower_index - upper_index)
+    return u.Quantity((up_norm, low_norm))

--- a/sunxspex/photon_power_law.py
+++ b/sunxspex/photon_power_law.py
@@ -5,6 +5,7 @@ import numpy as np
 
 PHOTON_RATE_UNIT = u.ph / u.keV / u.cm**2 / u.s
 
+
 @u.quantity_input
 def power_law_integral(
     energy: u.keV,

--- a/sunxspex/tests/test_photon_power_law.py
+++ b/sunxspex/tests/test_photon_power_law.py
@@ -12,8 +12,8 @@ def test_different_bins():
     energy_bins2 = np.linspace(10, 100, num=10) << u.keV
 
     shared_kw = dict(
-        reference_energy=3 << u.keV,
-        reference_flux=1 << ppl.PHOTON_RATE_UNIT,
+        norm_energy=3 << u.keV,
+        norm_flux=1 << ppl.PHOTON_RATE_UNIT,
         break_energy=20 << u.keV,
         lower_index=1,
         upper_index=3
@@ -58,8 +58,8 @@ def test_empty_or_single_energy_edges():
         edges = (np.arange(size) + 10) << u.keV
         with npt.assert_raises(ValueError):
             ppl.compute_broken_power_law(
-                energy_edges=edges << u.keV, reference_energy=1 << u.keV,
-                reference_flux=1 << ppl.PHOTON_RATE_UNIT, break_energy=3 << u.keV,
+                energy_edges=edges << u.keV, norm_energy=1 << u.keV,
+                norm_flux=1 << ppl.PHOTON_RATE_UNIT, break_energy=3 << u.keV,
                 lower_index=2, upper_index=3)
 
 
@@ -72,13 +72,13 @@ def test_one_big_bin():
     lower_index, upper_index = 2, 3
 
     ret = ppl.compute_broken_power_law(
-        energy_edges=edges, reference_energy=ref_eng,
-        reference_flux=ref_flux, break_energy=break_eng,
+        energy_edges=edges, norm_energy=ref_eng,
+        norm_flux=ref_flux, break_energy=break_eng,
         lower_index=lower_index, upper_index=upper_index)
 
     upper_norm, lower_norm = ppl._compute_broken_power_law_normalizations(
-        reference_flux=ref_flux,
-        reference_energy=ref_eng,
+        norm_flux=ref_flux,
+        norm_energy=ref_eng,
         break_energy=break_eng,
         lower_index=lower_index,
         upper_index=upper_index
@@ -107,8 +107,8 @@ def test_one_big_bin():
 
 def test_no_flux():
     ret = ppl.compute_broken_power_law(
-        energy_edges=[1, 2, 3] << u.keV, reference_energy=1 << u.keV,
-        reference_flux=0 << ppl.PHOTON_RATE_UNIT, break_energy=3 << u.keV,
+        energy_edges=[1, 2, 3] << u.keV, norm_energy=1 << u.keV,
+        norm_flux=0 << ppl.PHOTON_RATE_UNIT, break_energy=3 << u.keV,
         lower_index=2, upper_index=3)
     npt.assert_allclose(ret, np.zeros_like(ret))
 
@@ -118,8 +118,8 @@ def test_single_power_law():
     energy_bins2 = np.linspace(10, 100, num=10) << u.keV
 
     shared_kw = dict(
-        reference_energy=3 << u.keV,
-        reference_flux=1 << ppl.PHOTON_RATE_UNIT,
+        norm_energy=3 << u.keV,
+        norm_flux=1 << ppl.PHOTON_RATE_UNIT,
         index=2,
     )
 

--- a/sunxspex/tests/test_photon_power_law.py
+++ b/sunxspex/tests/test_photon_power_law.py
@@ -1,9 +1,9 @@
-import astropy.units as u
-from matplotlib import pyplot as plt
 import numpy as np
+from matplotlib import pyplot as plt
+
+import astropy.units as u
 
 from sunxspex import photon_power_law as ppl
-
 
 ''' i know this isn't really a test but it shows that things are working '''
 

--- a/sunxspex/tests/test_photon_power_law.py
+++ b/sunxspex/tests/test_photon_power_law.py
@@ -27,17 +27,11 @@ def test_different_bins():
     flux1 = np.sum(dist1 * np.diff(eb1))
     flux2 = np.sum(dist2 * np.diff(eb2))
 
-    import matplotlib.pyplot as plt
-    fig, ax = plt.subplots()
-    ax.stairs(dist1.value, eb1.value)
-    ax.stairs(dist2.value, eb2.value)
-    ax.set(xscale='log', yscale='log')
-    plt.show()
-
     npt.assert_allclose(flux1, flux2)
 
 
 def test_integration():
+    ''' test the actual power law integration '''
     for idx in range(10):
         n = 1 << ppl.PHOTON_RATE_UNIT
         norm_e = 3 << u.keV
@@ -60,8 +54,95 @@ def test_integration():
         npt.assert_allclose(calc_res, analytical_result)
 
 
+def test_empty_or_single_energy_edges():
+    ''' edge case: not enough energy bins given '''
+    for sz in (0, 1):
+        edges = (np.arange(sz) + 10) << u.keV
+        with npt.assert_raises(ValueError):
+            ppl.broken_power_law_binned_flux(
+                energy_edges=edges << u.keV, reference_energy=1 << u.keV,
+                reference_flux=1 << ppl.PHOTON_RATE_UNIT, break_energy=3 << u.keV,
+                lower_index=2, upper_index=3)
+
+
+def test_one_big_bin():
+    ''' edge case: single break energy in the middle of one big bin '''
+    edges = [1, 10] << u.keV
+    ref_eng = 1 << u.keV
+    break_eng = 3 << u.keV
+    ref_flux = 4 << ppl.PHOTON_RATE_UNIT
+    li, ui = 2, 3
+
+    ret = ppl.broken_power_law_binned_flux(
+        energy_edges=edges, reference_energy=ref_eng,
+        reference_flux=ref_flux, break_energy=break_eng,
+        lower_index=li, upper_index=ui)
+
+    un, ln = ppl.broken_power_law_normalizations(
+        reference_flux=ref_flux,
+        reference_energy=ref_eng,
+        break_energy=break_eng,
+        lower_index=li,
+        upper_index=ui
+    )
+
+    manual_result = np.diff(
+        ppl.power_law_integral(
+            energy=u.Quantity([edges[0], break_eng]),
+            norm_energy=ref_eng,
+            norm=ln,
+            index=li
+        )
+    )
+    manual_result += np.diff(
+        ppl.power_law_integral(
+            energy=u.Quantity([break_eng, edges[1]]),
+            norm_energy=ref_eng,
+            norm=un,
+            index=ui
+        )
+    )
+    manual_result /= np.diff(edges)
+
+    npt.assert_allclose(ret, manual_result)
+
+
+def test_no_flux():
+    ret = ppl.broken_power_law_binned_flux(
+        energy_edges=[1, 2, 3] << u.keV, reference_energy=1 << u.keV,
+        reference_flux=0 << ppl.PHOTON_RATE_UNIT, break_energy=3 << u.keV,
+        lower_index=2, upper_index=3)
+    npt.assert_allclose(ret, np.zeros_like(ret))
+
+
+def test_single_power_law():
+    eb1 = np.linspace(10, 100, num=30) << u.keV
+    eb2 = np.linspace(10, 100, num=10) << u.keV
+
+    shared_kw = dict(
+        reference_energy=3 << u.keV,
+        reference_flux=1 << ppl.PHOTON_RATE_UNIT,
+        index=2,
+    )
+
+    dist1 = ppl.power_law_binned_flux(energy_edges=eb1, **shared_kw)
+    dist2 = ppl.power_law_binned_flux(energy_edges=eb2, **shared_kw)
+
+    flux1 = np.sum(dist1 * np.diff(eb1))
+    flux2 = np.sum(dist2 * np.diff(eb2))
+
+    npt.assert_allclose(flux1, flux2)
+
+
 if __name__ == '__main__':
     def all_tests():
         test_integration()
         test_different_bins()
+
+        test_empty_or_single_energy_edges()
+        test_no_flux()
+        test_one_big_bin()
+
+        test_single_power_law()
+
     all_tests()

--- a/sunxspex/tests/test_photon_power_law.py
+++ b/sunxspex/tests/test_photon_power_law.py
@@ -78,7 +78,7 @@ def test_one_big_bin():
         reference_flux=ref_flux, break_energy=break_eng,
         lower_index=li, upper_index=ui)
 
-    un, ln = ppl.broken_power_law_normalizations(
+    un, ln = ppl._broken_power_law_normalizations(
         reference_flux=ref_flux,
         reference_energy=ref_eng,
         break_energy=break_eng,
@@ -138,11 +138,9 @@ if __name__ == '__main__':
     def all_tests():
         test_integration()
         test_different_bins()
-
         test_empty_or_single_energy_edges()
         test_no_flux()
         test_one_big_bin()
-
         test_single_power_law()
 
     all_tests()

--- a/sunxspex/tests/test_photon_power_law.py
+++ b/sunxspex/tests/test_photon_power_law.py
@@ -3,9 +3,7 @@ import numpy.testing as npt
 
 import astropy.units as u
 
-import sys
-sys.path.insert(0, '..')
-import photon_power_law as ppl
+from sunxspex import photon_power_law as ppl
 
 
 def test_different_bins():

--- a/sunxspex/tests/test_photon_power_law.py
+++ b/sunxspex/tests/test_photon_power_law.py
@@ -1,0 +1,33 @@
+import astropy.units as u
+from matplotlib import pyplot as plt
+import numpy as np
+
+from sunxspex import photon_power_law as ppl
+
+
+''' i know this isn't really a test but it shows that things are working '''
+
+def basic_plot_test():
+    paramz = dict()
+    paramz['energy_edges'] = (edges := np.logspace(0, 2, num=40) << u.keV)
+    paramz['reference_energy'] = 50 << u.keV
+    paramz['reference_flux'] = 10 << ppl.PHOTON_RATE_UNIT
+    paramz['break_energy'] = 20 << u.keV
+    paramz['lower_index'] = 1
+    paramz['upper_index'] = 6
+
+    flux = ppl.broken_power_law_binned_flux(**paramz)
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.stairs(flux.value, edges.value)
+    ax.set(
+        xlabel=edges.unit,
+        ylabel=flux.unit,
+        xscale='log',
+        yscale='log',
+        title='Broken power law'
+    )
+    plt.show()
+
+if __name__ == '__main__':
+    basic_plot_test()

--- a/sunxspex/tests/test_photon_power_law.py
+++ b/sunxspex/tests/test_photon_power_law.py
@@ -8,8 +8,8 @@ from sunxspex import photon_power_law as ppl
 
 def test_different_bins():
     ''' make sure that flux is conserved when using different energy bins '''
-    eb1 = np.linspace(10, 100, num=30) << u.keV
-    eb2 = np.linspace(10, 100, num=10) << u.keV
+    energy_bins1 = np.linspace(10, 100, num=30) << u.keV
+    energy_bins2 = np.linspace(10, 100, num=10) << u.keV
 
     shared_kw = dict(
         reference_energy=3 << u.keV,
@@ -19,11 +19,11 @@ def test_different_bins():
         upper_index=3
     )
 
-    dist1 = ppl.broken_power_law_binned_flux(energy_edges=eb1, **shared_kw)
-    dist2 = ppl.broken_power_law_binned_flux(energy_edges=eb2, **shared_kw)
+    dist1 = ppl.compute_broken_power_law(energy_edges=energy_bins1, **shared_kw)
+    dist2 = ppl.compute_broken_power_law(energy_edges=energy_bins2, **shared_kw)
 
-    flux1 = np.sum(dist1 * np.diff(eb1))
-    flux2 = np.sum(dist2 * np.diff(eb2))
+    flux1 = np.sum(dist1 * np.diff(energy_bins1))
+    flux2 = np.sum(dist2 * np.diff(energy_bins2))
 
     npt.assert_allclose(flux1, flux2)
 
@@ -31,33 +31,33 @@ def test_different_bins():
 def test_integration():
     ''' test the actual power law integration '''
     for idx in range(10):
-        n = 1 << ppl.PHOTON_RATE_UNIT
+        norm = 1 << ppl.PHOTON_RATE_UNIT
         norm_e = 3 << u.keV
         up_e, low_e = 4 << u.keV, 2 << u.keV
 
         if idx != 1:
             analytical_result = (
-                n * norm_e / (1 - idx) * (
+                norm * norm_e / (1 - idx) * (
                     (up_e / norm_e)**(1 - idx) - (low_e / norm_e)**(1 - idx)
                 )
             )
         else:
-            analytical_result = n * norm_e * np.log(up_e / low_e)
+            analytical_result = norm * norm_e * np.log(up_e / low_e)
 
-        calc_res = ppl.power_law_integral(
-            energy=up_e, norm_energy=norm_e, norm=n, index=idx)
-        calc_res -= ppl.power_law_integral(
-            energy=low_e, norm_energy=norm_e, norm=n, index=idx)
+        calc_res = ppl.integrate_power_law(
+            energy=up_e, norm_energy=norm_e, norm=norm, index=idx)
+        calc_res -= ppl.integrate_power_law(
+            energy=low_e, norm_energy=norm_e, norm=norm, index=idx)
 
         npt.assert_allclose(calc_res, analytical_result)
 
 
 def test_empty_or_single_energy_edges():
     ''' edge case: not enough energy bins given '''
-    for sz in (0, 1):
-        edges = (np.arange(sz) + 10) << u.keV
+    for size in (0, 1):
+        edges = (np.arange(size) + 10) << u.keV
         with npt.assert_raises(ValueError):
-            ppl.broken_power_law_binned_flux(
+            ppl.compute_broken_power_law(
                 energy_edges=edges << u.keV, reference_energy=1 << u.keV,
                 reference_flux=1 << ppl.PHOTON_RATE_UNIT, break_energy=3 << u.keV,
                 lower_index=2, upper_index=3)
@@ -69,35 +69,35 @@ def test_one_big_bin():
     ref_eng = 1 << u.keV
     break_eng = 3 << u.keV
     ref_flux = 4 << ppl.PHOTON_RATE_UNIT
-    li, ui = 2, 3
+    lower_index, upper_index = 2, 3
 
-    ret = ppl.broken_power_law_binned_flux(
+    ret = ppl.compute_broken_power_law(
         energy_edges=edges, reference_energy=ref_eng,
         reference_flux=ref_flux, break_energy=break_eng,
-        lower_index=li, upper_index=ui)
+        lower_index=lower_index, upper_index=upper_index)
 
-    un, ln = ppl._broken_power_law_normalizations(
+    upper_norm, lower_norm = ppl._compute_broken_power_law_normalizations(
         reference_flux=ref_flux,
         reference_energy=ref_eng,
         break_energy=break_eng,
-        lower_index=li,
-        upper_index=ui
+        lower_index=lower_index,
+        upper_index=upper_index
     )
 
     manual_result = np.diff(
-        ppl.power_law_integral(
+        ppl.integrate_power_law(
             energy=u.Quantity([edges[0], break_eng]),
             norm_energy=ref_eng,
-            norm=ln,
-            index=li
+            norm=lower_norm,
+            index=lower_index
         )
     )
     manual_result += np.diff(
-        ppl.power_law_integral(
+        ppl.integrate_power_law(
             energy=u.Quantity([break_eng, edges[1]]),
             norm_energy=ref_eng,
-            norm=un,
-            index=ui
+            norm=upper_norm,
+            index=upper_index
         )
     )
     manual_result /= np.diff(edges)
@@ -106,7 +106,7 @@ def test_one_big_bin():
 
 
 def test_no_flux():
-    ret = ppl.broken_power_law_binned_flux(
+    ret = ppl.compute_broken_power_law(
         energy_edges=[1, 2, 3] << u.keV, reference_energy=1 << u.keV,
         reference_flux=0 << ppl.PHOTON_RATE_UNIT, break_energy=3 << u.keV,
         lower_index=2, upper_index=3)
@@ -114,8 +114,8 @@ def test_no_flux():
 
 
 def test_single_power_law():
-    eb1 = np.linspace(10, 100, num=30) << u.keV
-    eb2 = np.linspace(10, 100, num=10) << u.keV
+    energy_bins1 = np.linspace(10, 100, num=30) << u.keV
+    energy_bins2 = np.linspace(10, 100, num=10) << u.keV
 
     shared_kw = dict(
         reference_energy=3 << u.keV,
@@ -123,11 +123,11 @@ def test_single_power_law():
         index=2,
     )
 
-    dist1 = ppl.power_law_binned_flux(energy_edges=eb1, **shared_kw)
-    dist2 = ppl.power_law_binned_flux(energy_edges=eb2, **shared_kw)
+    dist1 = ppl.compute_power_law(energy_edges=energy_bins1, **shared_kw)
+    dist2 = ppl.compute_power_law(energy_edges=energy_bins2, **shared_kw)
 
-    flux1 = np.sum(dist1 * np.diff(eb1))
-    flux2 = np.sum(dist2 * np.diff(eb2))
+    flux1 = np.sum(dist1 * np.diff(energy_bins1))
+    flux2 = np.sum(dist2 * np.diff(energy_bins2))
 
     npt.assert_allclose(flux1, flux2)
 

--- a/sunxspex/tests/test_photon_power_law.py
+++ b/sunxspex/tests/test_photon_power_law.py
@@ -7,6 +7,7 @@ from sunxspex import photon_power_law as ppl
 
 ''' i know this isn't really a test but it shows that things are working '''
 
+
 def basic_plot_test():
     paramz = dict()
     paramz['energy_edges'] = (edges := np.logspace(0, 2, num=40) << u.keV)
@@ -28,6 +29,7 @@ def basic_plot_test():
         title='Broken power law'
     )
     plt.show()
+
 
 if __name__ == '__main__':
     basic_plot_test()

--- a/sunxspex/tests/test_photon_power_law.py
+++ b/sunxspex/tests/test_photon_power_law.py
@@ -1,35 +1,67 @@
 import numpy as np
-from matplotlib import pyplot as plt
+import numpy.testing as npt
 
 import astropy.units as u
 
-from sunxspex import photon_power_law as ppl
+import sys
+sys.path.insert(0, '..')
+import photon_power_law as ppl
 
-''' i know this isn't really a test but it shows that things are working '''
 
+def test_different_bins():
+    ''' make sure that flux is conserved when using different energy bins '''
+    eb1 = np.linspace(10, 100, num=30) << u.keV
+    eb2 = np.linspace(10, 100, num=10) << u.keV
 
-def basic_plot_test():
-    paramz = dict()
-    paramz['energy_edges'] = (edges := np.logspace(0, 2, num=40) << u.keV)
-    paramz['reference_energy'] = 50 << u.keV
-    paramz['reference_flux'] = 10 << ppl.PHOTON_RATE_UNIT
-    paramz['break_energy'] = 20 << u.keV
-    paramz['lower_index'] = 1
-    paramz['upper_index'] = 6
-
-    flux = ppl.broken_power_law_binned_flux(**paramz)
-
-    fig, ax = plt.subplots(figsize=(8, 6))
-    ax.stairs(flux.value, edges.value)
-    ax.set(
-        xlabel=edges.unit,
-        ylabel=flux.unit,
-        xscale='log',
-        yscale='log',
-        title='Broken power law'
+    shared_kw = dict(
+        reference_energy=3 << u.keV,
+        reference_flux=1 << ppl.PHOTON_RATE_UNIT,
+        break_energy=20 << u.keV,
+        lower_index=1,
+        upper_index=3
     )
+
+    dist1 = ppl.broken_power_law_binned_flux(energy_edges=eb1, **shared_kw)
+    dist2 = ppl.broken_power_law_binned_flux(energy_edges=eb2, **shared_kw)
+
+    flux1 = np.sum(dist1 * np.diff(eb1))
+    flux2 = np.sum(dist2 * np.diff(eb2))
+
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots()
+    ax.stairs(dist1.value, eb1.value)
+    ax.stairs(dist2.value, eb2.value)
+    ax.set(xscale='log', yscale='log')
     plt.show()
+
+    npt.assert_allclose(flux1, flux2)
+
+
+def test_integration():
+    for idx in range(10):
+        n = 1 << ppl.PHOTON_RATE_UNIT
+        norm_e = 3 << u.keV
+        up_e, low_e = 4 << u.keV, 2 << u.keV
+
+        if idx != 1:
+            analytical_result = (
+                n * norm_e / (1 - idx) * (
+                    (up_e / norm_e)**(1 - idx) - (low_e / norm_e)**(1 - idx)
+                )
+            )
+        else:
+            analytical_result = n * norm_e * np.log(up_e / low_e)
+
+        calc_res = ppl.power_law_integral(
+            energy=up_e, norm_energy=norm_e, norm=n, index=idx)
+        calc_res -= ppl.power_law_integral(
+            energy=low_e, norm_energy=norm_e, norm=n, index=idx)
+
+        npt.assert_allclose(calc_res, analytical_result)
 
 
 if __name__ == '__main__':
-    basic_plot_test()
+    def all_tests():
+        test_integration()
+        test_different_bins()
+    all_tests()


### PR DESCRIPTION
PR

## PR Description
Adds photon space broken power law.

Compare with [f_bpow](https://ips.ucsd.edu/help/ssw/packages_f.html#F_BPOW) and [bknpower](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/node142.html).

The broken power law bins flux properly and uses an analytical antiderivative of a power law to do so.
The documentation is (mostly?) in line with other stuff I've seen in sunxspex so far.
Needs more tests!

Fixes #101 