### PR TITLE
Maintenance update min python versions and add testing for newer versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,14 +33,14 @@ repos:
       - id: isort
         args: ["--sp", "setup.cfg"]
         exclude: ".*(.fits|.fts|.fit|.txt|tca.*|extern.*|.rst|.md|cm/__init__.py|docs/conf.py)$"
-  - repo: https://github.com/hhatto/autopep8
+  - repo: https://github.com/pre-commit/mirrors-autopep8
     rev: v2.0.4
     hooks:
     -   id: autopep8
-        args: ["--in-place","--max-line-length", "200"]
+        args: ["--in-place", "--max-line-length", "200"]
         exclude: ".*(.fits|.fts|.fit|.txt|tca.*|extern.*|.rst|.md|cm/__init__.py)$"
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.3.0
     hooks:
       - id: check-ast
       - id: check-case-conflict

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: "3.9"
   apt_packages:
     - graphviz
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ variables:
   CI_NAME: Azure Pipelines
   CI_BUILD_ID: $(Build.BuildId)
   CI_BUILD_URL: "https://dev.azure.com/sunpy/sunxspex/_build/results?buildId=$(Build.BuildId)"
-  CIBW_BUILD: cp36-* cp37-* cp38-*
+  CIBW_BUILD: cp39-* cp310-* cp311-*
   CIBW_SKIP: "*-win32 *-manylinux1_i686"
 
 resources:
@@ -31,23 +31,51 @@ trigger:
 jobs:
 - template: run-tox-env.yml@OpenAstronomy
   parameters:
-    toxverspec: <4
-    toxdeps: tox-pypi-filter
     submodules: false
     coverage: codecov
     envs:
-      - macos: py38
-        name: py38_test_macos
-
-      - windows: py37
-        name: py37_win
-
-      - linux: py38
-        name: py38_lin
-
       - linux: codestyle
         name: codestyle
 
+      - linux: py39
+        name: py39_linux_test
+
+      - linux: py310
+        name: py310_linux_test
+
+      - linux: py311
+        name: py311_linux_test
+
+#      - linux: py312
+#        name: py312_linux_test
+
+      - macos: py39
+        name: py39_mac_test
+        coverage: false
+
+      - macos: py310
+        name: py310_mac_test
+        coverage: false
+
+      - macos: py311
+        name: py311_mac_test
+        coverage: false
+
+#      - macos: py312
+#        name: py312_mac_test
+#        coverage: false
+
+      - windows: py39
+        name: py39_win_test
+
+      - windows: py310
+        name: py310_win_test
+
+      - windows: py311
+        name: py311_win_test
+
+#      - windows: py312
+#        name: py312_win_test
 
 # On branches which aren't master, and not Pull Requests, build the wheels but only upload them on tags
 - ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), not(contains(variables['Build.SourceBranch'], 'master'))) }}:
@@ -65,6 +93,16 @@ jobs:
         - wheels_macos
         - sdist
       dependsOn:
-        - py38_test_macos
-        - py37_test
-        - py38_test
+        - codestyle
+        - py39_linux_test
+        - py310_linux_test
+        - py311_linux_test
+#        - py312_linux_test
+        - py39_mac_test
+        - py310_mac_test
+        - py311_mac_test
+#        - py312_mac_test
+        - py39_win_test
+        - py310_win_test
+        - py311_win_test
+#        - py312_win_test

--- a/changelog/121.breaking.rst
+++ b/changelog/121.breaking.rst
@@ -1,0 +1,1 @@
+Update minimum python version to python version to 3.9 and add testing for 3.10 and 3.11.

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,11 @@ long_description = file: README.rst
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires =
     sunpy
-    parfive < 2.0
+    parfive
     scipy
     xarray
     quadpy
@@ -28,6 +28,7 @@ install_requires =
     nestle
     numdifftools
 
+
 [options.extras_require]
 test =
     pytest
@@ -38,6 +39,8 @@ docs =
     sphinx
     sphinx-automodapi
     sunpy-sphinx-theme
+    # Remove next line when fixed in towncrier; see https://github.com/twisted/towncrier/issues/528
+    importlib-resources<6
     sphinx-changelog>=1.1.1
 
 [options.package_data]

--- a/sunkit_spex/emission.py
+++ b/sunkit_spex/emission.py
@@ -167,7 +167,7 @@ class BrokenPowerLawElectronDistribution:
 
     def __repr__(self):
         return f'{self.__class__.__name__}(p={self.p}, q={self.q}, eelow={self.eelow}, ' \
-               f'eebrk={self.eebrk}, eehigh={self.eehigh}, norm={self.norm})'
+            f'eebrk={self.eebrk}, eehigh={self.eehigh}, norm={self.norm})'
 
 
 def collisional_loss(electron_energy):

--- a/sunkit_spex/sunxspex_fitting/data_loader.py
+++ b/sunkit_spex/sunxspex_fitting/data_loader.py
@@ -9,8 +9,8 @@ import numpy as np
 from astropy.io import fits
 
 
-from sunkit_spex.sunxspex_fitting import instruments as inst  # Fitter.sunxspex_fitting.instruments
-from sunkit_spex.sunxspex_fitting.parameter_handler import (  # Fitter.sunxspex_fitting.parameter_handler
+from sunkit_spex.sunxspex_fitting import instruments as inst  # sunkit_spex.sunxspex_fitting.instruments
+from sunkit_spex.sunxspex_fitting.parameter_handler import (  # sunkit_spex.sunxspex_fitting.parameter_handler
     _make_into_list,
     isnumber,
 )
@@ -123,8 +123,7 @@ class LoadSpec:
 
         self._construction_string = f"LoadSpec(*{args},pha_file={pha_file},arf_file={arf_file},rmf_file={rmf_file},srm_file={srm_file},srm_custom={srm_custom},custom_channel_bins={custom_channel_bins}, **{kwargs})"
 
-        # from sunkit_spec.sunxspex_fitting.instruments import * gives us the instrument specific loaders, keys should match up to the "TELESCOP" header entry in spec file
-
+        # from sunkit_spex.sunxspex_fitting.instruments import * gives us the instrument specific loaders, keys should match up to the "TELESCOP" header entry in spec file
         self.instrument_loaders = {"NuSTAR": inst.NustarLoader, "SOLO/STIX": inst.StixLoader, "RHESSI": inst.RhessiLoader}
 
         pha_file, arf_file, rmf_file, srm_file, srm_custom, custom_channel_bins, instruments = self._sort_files(pha_file=pha_file,

--- a/sunkit_spex/sunxspex_fitting/data_loader.py
+++ b/sunkit_spex/sunxspex_fitting/data_loader.py
@@ -8,8 +8,9 @@ import numpy as np
 
 from astropy.io import fits
 
-from sunkit_spex.sunxspex_fitting import instruments as inst  # sunkit_spex.sunxspex_fitting.instruments
-from sunkit_spex.sunxspex_fitting.parameter_handler import (  # sunkit_spex.sunxspex_fitting.parameter_handler
+
+from sunkit_spex.sunxspex_fitting import instruments as inst  # Fitter.sunxspex_fitting.instruments
+from sunkit_spex.sunxspex_fitting.parameter_handler import (  # Fitter.sunxspex_fitting.parameter_handler
     _make_into_list,
     isnumber,
 )
@@ -122,7 +123,8 @@ class LoadSpec:
 
         self._construction_string = f"LoadSpec(*{args},pha_file={pha_file},arf_file={arf_file},rmf_file={rmf_file},srm_file={srm_file},srm_custom={srm_custom},custom_channel_bins={custom_channel_bins}, **{kwargs})"
 
-        # from sunkit_spex.sunxspex_fitting.instruments import * gives us the instrument specific loaders, keys should match up to the "TELESCOP" header entry in spec file
+        # from sunkit_spec.sunxspex_fitting.instruments import * gives us the instrument specific loaders, keys should match up to the "TELESCOP" header entry in spec file
+
         self.instrument_loaders = {"NuSTAR": inst.NustarLoader, "SOLO/STIX": inst.StixLoader, "RHESSI": inst.RhessiLoader}
 
         pha_file, arf_file, rmf_file, srm_file, srm_custom, custom_channel_bins, instruments = self._sort_files(pha_file=pha_file,

--- a/sunkit_spex/sunxspex_fitting/data_loader.py
+++ b/sunkit_spex/sunxspex_fitting/data_loader.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from astropy.io import fits
 
-
 from sunkit_spex.sunxspex_fitting import instruments as inst  # sunkit_spex.sunxspex_fitting.instruments
 from sunkit_spex.sunxspex_fitting.parameter_handler import (  # sunkit_spex.sunxspex_fitting.parameter_handler
     _make_into_list,
@@ -121,7 +120,8 @@ class LoadSpec:
     def __init__(self, *args, pha_file=None, arf_file=None, rmf_file=None, srm_file=None, srm_custom=None, custom_channel_bins=None, **kwargs):
         """Construct a string to show how the class was constructed (`_construction_string`) and set the `loaded_spec_data` dictionary attribute."""
 
-        self._construction_string = f"LoadSpec(*{args},pha_file={pha_file},arf_file={arf_file},rmf_file={rmf_file},srm_file={srm_file},srm_custom={srm_custom},custom_channel_bins={custom_channel_bins}, **{kwargs})"
+        self._construction_string = (f"LoadSpec(*{args}, pha_file={pha_file}, arf_file={arf_file}, rmf_file={rmf_file}, "
+                                     f"srm_file={srm_file}, srm_custom={srm_custom}, custom_channel_bins={custom_channel_bins}, **{kwargs})")
 
         # from sunkit_spex.sunxspex_fitting.instruments import * gives us the instrument specific loaders, keys should match up to the "TELESCOP" header entry in spec file
         self.instrument_loaders = {"NuSTAR": inst.NustarLoader, "SOLO/STIX": inst.StixLoader, "RHESSI": inst.RhessiLoader}

--- a/sunkit_spex/sunxspex_fitting/fitter.py
+++ b/sunkit_spex/sunxspex_fitting/fitter.py
@@ -401,7 +401,8 @@ class Fitter:
         self.data = LoadSpec(*args, pha_file=pha_file, arf_file=arf_file, rmf_file=rmf_file, srm_file=srm_file, srm_custom=srm_custom,
                              custom_channel_bins=custom_channel_bins, custom_photon_bins=custom_photon_bins, **kwargs)
 
-        self._construction_string_sunxspex = f"Fitter({args},pha_file={pha_file},arf_file={arf_file},rmf_file={rmf_file},srm_file={srm_file},srm_custom={srm_custom},custom_channel_bins={custom_channel_bins},custom_photon_bins={custom_photon_bins},**{kwargs})"
+        self._construction_string_sunxspex = (f"Fitter({args}, pha_file={pha_file}, arf_file={arf_file}, rmf_file={rmf_file}, srm_file={srm_file}, "
+                                              f"srm_custom={srm_custom}, custom_channel_bins={custom_channel_bins}, custom_photon_bins={custom_photon_bins}, **{kwargs})")
 
         self.loglikelihood = "cstat"
 
@@ -779,7 +780,6 @@ class Fitter:
             logger.warning(
                 "Default models imported from sunkit_spex.sunxspex_fitting.photon_models_for_fitting are protected.")
 
-
     def add_var(self, overwrite=False, quiet=False, **user_kwarg):
         """ Add user variable to fitting namespace.
 
@@ -846,7 +846,7 @@ class Fitter:
         for k, i in user_kwarg.items():
             if k in self.dynamic_vars and not overwrite:
                 vb = f"Variable {k} already exists. Please set `overwrite=True`, delete this with " \
-                     f"`del_var({k})`,\nor use a different variable name."
+                    f"`del_var({k})`,\nor use a different variable name."
             elif not k in self.dynamic_vars:
                 vb = f"Argument name {k} already exists **in globals** and is not a good idea to " \
                     f"overwrite. Please use a different variable name."
@@ -2047,7 +2047,8 @@ class Fitter:
         photon_channel_bins, photon_channel_mids, photon_channel_widths, srm = self._photon_space_reduce(ph_bins=photon_channel_bins,
                                                                                                          ph_mids=photon_channel_mids,
                                                                                                          ph_widths=photon_e_binning,
-                                                                                                         srm=srm)  # arf (for NuSTAR at least) makes ~half of the rows all zeros (>80 keV), remove them and cut fitting time by a third
+                                                                                                         # arf (for NuSTAR at least) makes ~half of the rows all zeros (>80 keV), remove them and cut fitting time by a third
+                                                                                                         srm=srm)
         # photon_e_binning
 
         # remove the count space reduce since this now needs to reduce the livetimes and baclgrounds if they are there
@@ -2337,7 +2338,8 @@ class Fitter:
         photon_channel_bins, _, _, srm = self._photon_space_reduce(ph_bins=[self.data.loaded_spec_data[spectrum]['photon_channel_bins']],
                                                                    ph_mids=[self.data.loaded_spec_data[spectrum]['photon_channel_bins']],
                                                                    ph_widths=[self.data.loaded_spec_data[spectrum]['photon_channel_binning']],
-                                                                   srm=[self.data.loaded_spec_data[spectrum]['srm']])  # arf (for NuSTAR at least) makes ~half of the rows all zeros (>80 keV), remove them and cut fitting time by a third
+                                                                   # arf (for NuSTAR at least) makes ~half of the rows all zeros (>80 keV), remove them and cut fitting time by a third
+                                                                   srm=[self.data.loaded_spec_data[spectrum]['srm']])
         photon_channel_bins, srm = photon_channel_bins[0], srm[0]
 
         if type(parameters) == type(None):

--- a/sunkit_spex/sunxspex_fitting/fitter.py
+++ b/sunkit_spex/sunxspex_fitting/fitter.py
@@ -779,6 +779,7 @@ class Fitter:
             logger.warning(
                 "Default models imported from sunkit_spex.sunxspex_fitting.photon_models_for_fitting are protected.")
 
+
     def add_var(self, overwrite=False, quiet=False, **user_kwarg):
         """ Add user variable to fitting namespace.
 

--- a/sunkit_spex/sunxspex_fitting/fitter.py
+++ b/sunkit_spex/sunxspex_fitting/fitter.py
@@ -653,7 +653,7 @@ class Fitter:
 
         Takes a user defined function intended to be used as a model or model component when
         giving a
-        string to the Fitter.model property. Puts defined_photon_models[
+        string to the sunkit_spex.model property. Puts defined_photon_models[
         function.__name__]=param_inputs
         in `defined_photon_models` for it to be known to the fititng code. The energies argument
         must be
@@ -4719,7 +4719,7 @@ def load(filename):
         loaded = pickle.load(f)
     return loaded
 
-# The following functions allows Fitter.model take lambda functions and strings as inputs then convert them to named functions
+# The following functions allows sunkit_spex.model take lambda functions and strings as inputs then convert them to named functions
 
 
 def _func_self_contained_check(function_name, function_text):

--- a/sunkit_spex/sunxspex_fitting/fitter.py
+++ b/sunkit_spex/sunxspex_fitting/fitter.py
@@ -653,7 +653,7 @@ class Fitter:
 
         Takes a user defined function intended to be used as a model or model component when
         giving a
-        string to the sunkit_spex.model property. Puts defined_photon_models[
+        string to the Fitter.model property. Puts defined_photon_models[
         function.__name__]=param_inputs
         in `defined_photon_models` for it to be known to the fititng code. The energies argument
         must be
@@ -4719,7 +4719,7 @@ def load(filename):
         loaded = pickle.load(f)
     return loaded
 
-# The following functions allows sunkit_spex.model take lambda functions and strings as inputs then convert them to named functions
+# The following functions allows Fitter.model take lambda functions and strings as inputs then convert them to named functions
 
 
 def _func_self_contained_check(function_name, function_text):

--- a/sunkit_spex/sunxspex_fitting/instruments.py
+++ b/sunkit_spex/sunxspex_fitting/instruments.py
@@ -235,7 +235,8 @@ class NustarLoader(InstrumentBlueprint):
     def __init__(self, pha_file, arf_file=None, rmf_file=None, srm_custom=None, custom_channel_bins=None, custom_photon_bins=None, **kwargs):
         """Construct a string to show how the class was constructed (`_construction_string`) and set the `_loaded_spec_data` dictionary attribute."""
 
-        self._construction_string = f"NustarLoader(pha_file={pha_file},arf_file={arf_file},rmf_file={rmf_file},srm_custom={srm_custom},custom_channel_bins={custom_channel_bins},custom_photon_bins={custom_photon_bins},**{kwargs})"
+        self._construction_string = (f"NustarLoader(pha_file={pha_file}, arf_file={arf_file}, rmf_file={rmf_file}, srm_custom={srm_custom}, "
+                                     f"custom_channel_bins={custom_channel_bins}, custom_photon_bins={custom_photon_bins}, **{kwargs})")
         self._loaded_spec_data = self._load1spec(pha_file, f_arf=arf_file, f_rmf=rmf_file, srm=srm_custom, channel_bins=custom_channel_bins, photon_bins=custom_photon_bins)
 
     def _load1spec(self, f_pha, f_arf=None, f_rmf=None, srm=None, channel_bins=None, photon_bins=None):
@@ -569,7 +570,8 @@ class RhessiLoader(InstrumentBlueprint):
     def __init__(self, pha_file, srm_file=None, srm_custom=None, custom_channel_bins=None, custom_photon_bins=None, **kwargs):
         """Construct a string to show how the class was constructed (`_construction_string`) and set the `_loaded_spec_data` dictionary attribute."""
 
-        self._construction_string = f"RhessiLoader(pha_file={pha_file},srm_file={srm_file},srm_custom={srm_custom},custom_channel_bins={custom_channel_bins},custom_photon_bins={custom_photon_bins},**{kwargs})"
+        self._construction_string = (f"RhessiLoader(pha_file={pha_file}, srm_file={srm_file}, srm_custom={srm_custom}, "
+                                     f"custom_channel_bins={custom_channel_bins}, custom_photon_bins={custom_photon_bins}, **{kwargs})")
         self._loaded_spec_data = self._load1spec(pha_file, srm_file, srm=srm_custom, channel_bins=custom_channel_bins, photon_bins=custom_photon_bins)
 
         self._time_fmt, self._time_scale = "isot", "utc"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38}
+    py{39,310,311}
     build_docs
     codestyle
 isolated_build = true
@@ -20,7 +20,7 @@ requires =
 pypi_filter_requirements = https://raw.githubusercontent.com/sunpy/package-template/master/sunpy_version_pins.txt
 
 # Pass through the following environemnt variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+passenv = HOME, WINDIR, LC_ALL, LC_CTYPE, CC, CI, TRAVIS
 
 # Run the tests in a temporary directory to make sure that we don't import
 # the package from the source tree
@@ -59,5 +59,6 @@ description = Run all style and file checks with pre-commit
 deps =
     pre-commit
 commands =
+    python -V
     pre-commit install-hooks
     pre-commit run --all-files


### PR DESCRIPTION
* Major version support [NEP29](ttps://numpy.org/neps/nep-0029-deprecation_policy.htm)
   * python version min version now 3.9, 3.10, 3.11. *3.12*
* Temporarily disable code coverage on macOS CI as not working
