### PR TITLE
Add caching of CHIANTI files to GHA 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,9 @@ jobs:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
-      cache-path: |
-        $HOME/sunpy/data_manager
-      cache-key: sunpy-data-linux-${{ github.ref }}
-      cache-restore-keys: sunpy-data-linux-refs/heads/main
+      cache-path: ~/sunpy/data_manager
+      cache-key: sunpy-data-${{ runner.os }}-${{ github.ref }}
+      cache-restore-keys: sunpy-data-${{ runner.os }}-refs/heads/main
       envs: |
         - linux: py313
     secrets:
@@ -66,31 +65,16 @@ jobs:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
-      cache-path: |
-        $HOME/sunpy/data_manager
-      cache-key: sunpy-data-${{ github.ref }}
+      cache-path: ~/sunpy/data_manager
+      cache-key: sunpy-data-${{ runner.os }}-${{ github.ref }}
+      cache-restore-keys: sunpy-data-${{ runner.os }}-refs/heads/main
       posargs:
       envs: |
         - linux: py314
-          cache-path: $HOME/sunpy/data_manager
-          cache-key: sunpy-data-linux-${{ github.ref }}
-          cache-restore-keys: sunpy-data-linux-refs/heads/main
         - windows: py312
-          cache-path: $HOME/sunpy/data_manager
-          cache-key: sunpy-data-windows-${{ github.ref }}
-          cache-restore-keys: sunpy-data-windows-refs/heads/main
         - macos: py312
-          cache-path: $HOME/sunpy/data_manager
-          cache-key: sunpy-data-macos-${{ github.ref }}
-          ache-restore-keys: sunpy-data-macos-refs/heads/main
         - linux: py312-oldestdeps
-          cache-path: $HOME/sunpy/data_manager
-          cache-key: sunpy-data-linux-${{ github.ref }}
-          cache-restore-keys: sunpy-data-linux-refs/heads/main
         - linux: py314-devdeps
-          cache-path: $HOME/sunpy/data_manager
-          cache-key: sunpy-data-linux-${{ github.ref }}
-          cache-restore-keys: sunpy-data-linux-refs/heads/main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       cache-path: ~/sunpy/data_manager
-      cache-key: sunpy-data-${{ runner.os }}-${{ github.ref }}
-      cache-restore-keys: sunpy-data-${{ runner.os }}-refs/heads/main
       envs: |
         - linux: py313
+          cache-key: sunpy-data-linux-${{ github.ref }}
+          cache-restore-keys: sunpy-data-linux-refs/heads/main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -66,15 +66,23 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       cache-path: ~/sunpy/data_manager
-      cache-key: sunpy-data-${{ runner.os }}-${{ github.ref }}
-      cache-restore-keys: sunpy-data-${{ runner.os }}-refs/heads/main
       posargs:
       envs: |
         - linux: py314
+          cache-key: sunpy-data-linux-${{ github.ref }}
+          cache-restore-keys: sunpy-data-linux-refs/heads/main
         - windows: py312
+          cache-key: sunpy-data-windows-${{ github.ref }}
+          cache-restore-keys: sunpy-data-windows-refs/heads/main
         - macos: py312
+          cache-key: sunpy-data-macos-${{ github.ref }}
+          ache-restore-keys: sunpy-data-macos-refs/heads/main
         - linux: py312-oldestdeps
+          cache-key: sunpy-data-linux-${{ github.ref }}
+          cache-restore-keys: sunpy-data-linux-refs/heads/main
         - linux: py314-devdeps
+          cache-key: sunpy-data-linux-${{ github.ref }}
+          cache-restore-keys: sunpy-data-linux-refs/heads/main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       cache-path: |
         $HOME/sunpy/data_manager
       cache-key: sunpy-data-linux-${{ github.ref }}
+      cache-restore-keys: sunpy-data-linux-refs/heads/main
       envs: |
         - linux: py313
     secrets:
@@ -73,18 +74,23 @@ jobs:
         - linux: py314
           cache-path: $HOME/sunpy/data_manager
           cache-key: sunpy-data-linux-${{ github.ref }}
+          cache-restore-keys: sunpy-data-linux-refs/heads/main
         - windows: py312
           cache-path: $HOME/sunpy/data_manager
           cache-key: sunpy-data-windows-${{ github.ref }}
+          cache-restore-keys: sunpy-data-windows-refs/heads/main
         - macos: py312
           cache-path: $HOME/sunpy/data_manager
           cache-key: sunpy-data-macos-${{ github.ref }}
+          ache-restore-keys: sunpy-data-macos-refs/heads/main
         - linux: py312-oldestdeps
           cache-path: $HOME/sunpy/data_manager
           cache-key: sunpy-data-linux-${{ github.ref }}
+          cache-restore-keys: sunpy-data-linux-refs/heads/main
         - linux: py314-devdeps
           cache-path: $HOME/sunpy/data_manager
           cache-key: sunpy-data-linux-${{ github.ref }}
+          cache-restore-keys: sunpy-data-linux-refs/heads/main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,7 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       cache-path: |
-        ~/sunpy/data_manager/*.sav
-        ~/sunpy/data_manager/*.genx
+        ~/sunpy/data_manager
       cache-key: sunpy-data-${{ github.ref }}
       envs: |
         - linux: py313
@@ -67,8 +66,7 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       cache-path: |
-        ~/sunpy/data_manager/*.sav
-        ~/sunpy/data_manager/*.genx
+        ~/sunpy/data_manager
       cache-key: sunpy-data-${{ github.ref }}
       posargs:
       envs: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
+      cache-path: |
+        ~/sunpy/data_manager/*.sav
+        ~/sunpy/data_manager/*.genx
+      cache-key: sunpy-data-${{ github.ref }}
       envs: |
         - linux: py313
     secrets:
@@ -62,6 +66,10 @@ jobs:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
+      cache-path: |
+        ~/sunpy/data_manager/*.sav
+        ~/sunpy/data_manager/*.genx
+      cache-key: sunpy-data-${{ github.ref }}
       posargs:
       envs: |
         - linux: py314

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       cache-path: |
-        ~/sunpy/data_manager
+        $HOME/sunpy/data_manager
       cache-key: sunpy-data-${{ github.ref }}
       envs: |
         - linux: py313
@@ -66,7 +66,7 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       cache-path: |
-        ~/sunpy/data_manager
+        $HOME/sunpy/data_manager
       cache-key: sunpy-data-${{ github.ref }}
       posargs:
       envs: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,12 +94,15 @@ jobs:
       submodules: false
       pytest: false
       toxdeps: tox-pypi-filter
+      cache-path: ~/sunpy/data_manager
       libraries: |
         apt:
           - graphviz
           - pandoc
       envs: |
         - linux: build_docs
+          cache-key: sunpy-data-linux-${{ github.ref }}
+          cache-restore-keys: sunpy-data-linux-refs/heads/main
 
   build_dists:
     # Build wheels on PRs only when labelled. Releases will only be published if tagged ^v.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       toxdeps: tox-pypi-filter
       cache-path: |
         $HOME/sunpy/data_manager
-      cache-key: sunpy-data-${{ github.ref }}
+      cache-key: sunpy-data-linux-${{ github.ref }}
       envs: |
         - linux: py313
     secrets:
@@ -71,10 +71,20 @@ jobs:
       posargs:
       envs: |
         - linux: py314
+          cache-path: $HOME/sunpy/data_manager
+          cache-key: sunpy-data-linux-${{ github.ref }}
         - windows: py312
+          cache-path: $HOME/sunpy/data_manager
+          cache-key: sunpy-data-windows-${{ github.ref }}
         - macos: py312
+          cache-path: $HOME/sunpy/data_manager
+          cache-key: sunpy-data-macos-${{ github.ref }}
         - linux: py312-oldestdeps
+          cache-path: $HOME/sunpy/data_manager
+          cache-key: sunpy-data-linux-${{ github.ref }}
         - linux: py314-devdeps
+          cache-path: $HOME/sunpy/data_manager
+          cache-key: sunpy-data-linux-${{ github.ref }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## PR Description

Use openastronomy GHA templates caching features to cache the CHIANTI files.

So what should ideally happen with this PR is that once it's merge to main it will run and generate the cache entries for each os with keys ending in `refs/heads/main` e.g. `sunpy-data-linux-refs/heads/main` then any subsequent run will restore the cache from these keys

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
