### PR TITLE
Doc typo

### DIFF
--- a/changelog/289.doc.rst
+++ b/changelog/289.doc.rst
@@ -1,0 +1,1 @@
+Online docs build now shows "Spectrum" title in "Reference" rather than a second "Models" sections due to a typo.

--- a/docs/reference/spectrum.rst
+++ b/docs/reference/spectrum.rst
@@ -1,5 +1,5 @@
-Models (`sunkit_spex.spectrum`)
-*******************************
+Spectrum (`sunkit_spex.spectrum`)
+*********************************
 
 ``sunkit_spex.spectrum`` module contains objects for holding spectral data
 

--- a/docs/reference/spectrum.rst
+++ b/docs/reference/spectrum.rst
@@ -3,5 +3,5 @@ Spectrum (`sunkit_spex.spectrum`)
 
 ``sunkit_spex.spectrum`` module contains objects for holding spectral data
 
-.. automodapi:: sunkit_spex.spectrum
+.. automodapi:: sunkit_spex.spectrum 
 .. automodapi:: sunkit_spex.spectrum.spectrum

--- a/docs/reference/spectrum.rst
+++ b/docs/reference/spectrum.rst
@@ -3,5 +3,5 @@ Spectrum (`sunkit_spex.spectrum`)
 
 ``sunkit_spex.spectrum`` module contains objects for holding spectral data
 
-.. automodapi:: sunkit_spex.spectrum 
+.. automodapi:: sunkit_spex.spectrum
 .. automodapi:: sunkit_spex.spectrum.spectrum


### PR DESCRIPTION
Very short typo fix. 

In the "Reference" section in the online docs, it showed two "Models" sections. One was of the "Models" module but the other was of the "Spectrum" module, just due to a small typo. I've fixed the typo and now the section heading is fixed.